### PR TITLE
Persist real-time suggestions state

### DIFF
--- a/Core/Sources/Client/XPCService.swift
+++ b/Core/Sources/Client/XPCService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XPCShared
+import os.log
 
 var asyncService: AsyncXPCService?
 var shared = XPCService()
@@ -30,11 +31,11 @@ class XPCService {
         connection.remoteObjectInterface =
             NSXPCInterface(with: XPCServiceProtocol.self)
         connection.invalidationHandler = { [weak self] in
-            print("XPCService Invalidated")
+            os_log(.info, "XPCService Invalidated")
             self?.isInvalidated = true
         }
         connection.interruptionHandler = { [weak self] in
-            print("XPCService interrupted")
+            os_log(.info, "XPCService interrupted")
         }
         connection.resume()
         return connection

--- a/Core/Sources/Service/AutoTrigger.swift
+++ b/Core/Sources/Service/AutoTrigger.swift
@@ -1,14 +1,17 @@
+import AppKit
 import Foundation
 import XPCShared
+import os.log
 
-actor AutoTrigger {
-    static let shared = AutoTrigger()
+public actor AutoTrigger {
+    public static let shared = AutoTrigger()
 
-    private var listeners = Set<ObjectIdentifier>()
+    private var listeners = Set<AnyHashable>()
     var eventObserver: CGEventObserverType = CGEventObserver()
     var task: Task<Void, Error>?
 
     private init() {
+        // Occasionally cleanup workspaces.
         Task { @ServiceActor in
             while !Task.isCancelled {
                 try await Task.sleep(nanoseconds: 8 * 60 * 60 * 1_000_000_000)
@@ -21,15 +24,42 @@ actor AutoTrigger {
                 }
             }
         }
+        
+        // Start the auto trigger if Xcode is running.
+        Task {
+            for xcode in await Environment.runningXcodes() {
+                await start(by: xcode.processIdentifier)
+            }
+            let sequence = NSWorkspace.shared.notificationCenter
+                .notifications(named: NSWorkspace.didLaunchApplicationNotification)
+            for await notification in sequence {
+                try Task.checkCancellation()
+                guard let app =  notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { continue }
+                guard app.bundleIdentifier == "com.apple.dt.Xcode" else { continue }
+                await start(by: app.processIdentifier)
+            }
+        }
+        
+        // Remove listener if Xcode is terminated.
+        Task {
+            let sequence = NSWorkspace.shared.notificationCenter
+                .notifications(named: NSWorkspace.didTerminateApplicationNotification)
+            for await notification in sequence {
+                try Task.checkCancellation()
+                guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { continue }
+                guard app.bundleIdentifier == "com.apple.dt.Xcode" else { continue }
+                await stop(by: app.processIdentifier)
+            }
+        }
     }
 
-    func start(by listener: ObjectIdentifier) {
+    func start(by listener: AnyHashable) {
+        os_log(.info, "Add auto trigger listener: %@.", listener as CVarArg)
         listeners.insert(listener)
 
         if task == nil {
             task = Task { [stream = eventObserver.stream] in
                 var triggerTask: Task<Void, Error>?
-                try? await Environment.triggerAction("Prefetch Suggestions")
                 for await _ in stream {
                     triggerTask?.cancel()
                     if Task.isCancelled { break }
@@ -47,10 +77,11 @@ actor AutoTrigger {
                         try? await Task.sleep(nanoseconds: 2_000_000_000)
                         if Task.isCancelled { return }
                         let fileURL = try? await Environment.fetchCurrentFileURL()
-                        guard let folderURL = try? await Environment.fetchCurrentProjectRootURL(fileURL),
-                              let workspace = workspaces[folderURL],
-                              workspace.isRealtimeSuggestionEnabled
+                        guard let folderURL = try? await Environment.fetchCurrentProjectRootURL(fileURL)
                         else { return }
+                        let workspace = workspaces[folderURL] ?? Workspace(projectRootURL: folderURL)
+                        workspaces[folderURL] = workspace
+                        guard workspace.isRealtimeSuggestionEnabled else { return }
                         if Task.isCancelled { return }
                         try? await Environment.triggerAction("Prefetch Suggestions")
                     }
@@ -60,9 +91,11 @@ actor AutoTrigger {
         eventObserver.activateIfPossible()
     }
 
-    func stop(by listener: ObjectIdentifier) {
+    func stop(by listener: AnyHashable) {
+        os_log(.info, "Remove auto trigger listener: %@.", listener as CVarArg)
         listeners.remove(listener)
         guard listeners.isEmpty else { return }
+        os_log(.info, "Auto trigger is stopped.")
         task?.cancel()
         task = nil
         eventObserver.deactivate()

--- a/Core/Sources/Service/CGEventObserver.swift
+++ b/Core/Sources/Service/CGEventObserver.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import Foundation
+import os.log
 
 public protocol CGEventObserverType {
     @discardableResult
@@ -38,7 +39,7 @@ final class CGEventObserver: CGEventObserverType {
         retryTask?.cancel()
         retryTask = nil
         guard let port = port else { return }
-        print("Deactivate")
+        os_log(.info, "CGEventObserver deactivated.")
         CFMachPortInvalidate(port)
         self.port = nil
     }
@@ -95,6 +96,7 @@ final class CGEventObserver: CGEventObserverType {
         self.port = port
         let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
         CFRunLoopAddSource(RunLoop.main.getCFRunLoop(), runLoopSource, .commonModes)
+        os_log(.info, "CGEventObserver activated.")
         return true
     }
 }

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -45,7 +45,12 @@ final class Workspace {
     }
 
     var filespaces = [URL: Filespace]()
-    var isRealtimeSuggestionEnabled = false
+    var isRealtimeSuggestionEnabled: Bool {
+        (UserDefaults.shared.dictionary(
+            forKey: SettingsKey.realtimeSuggestionState
+        )?[projectRootURL.absoluteString]) as? Bool ?? false
+    }
+
     var realtimeSuggestionRequests = Set<Task<Void, Error>>()
 
     private lazy var service: CopilotSuggestionServiceType = Environment

--- a/Core/Sources/Service/XPCService.swift
+++ b/Core/Sources/Service/XPCService.swift
@@ -26,7 +26,10 @@ public class XPCService: NSObject, XPCServiceProtocol {
 
     deinit {
         let identifier = ObjectIdentifier(self)
-        Task {
+        Task { @ServiceActor in
+            for (_, workspace) in workspaces {
+                workspace.isRealtimeSuggestionEnabled = false
+            }
             await AutoTrigger.shared.stop(by: identifier)
         }
     }

--- a/Core/Sources/XPCShared/UserDefaults.swift
+++ b/Core/Sources/XPCShared/UserDefaults.swift
@@ -6,4 +6,5 @@ public extension UserDefaults {
 
 public enum SettingsKey {
     public static let nodePath = "NodePath"
+    public static let realtimeSuggestionState = "RealtimeSuggestionState"
 }

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ The first time the commands run, the extension will ask for 2 types of permissio
 
 **About real-time suggestions**
 
-The implementation won't feel as smooth as that of VSCode.
+- The on/off state is not persisted, they will be reset every time Xcode is quit. (For technical reasons, you always need to run a random command to start the XPCService, it will be confusing if it's persisted.)
+- The implementation won't feel as smooth as that of VSCode.
+  
+    The magic behind it is that it will keep calling the command from the menu when you are not typing or clicking the mouse. So it will have to listen to those events, I am not sure if people like it.
 
-The magic behind it is that it will keep calling the command from the menu when you are not typing, or clicking mouse. So it will have to listen to those events, I am not sure if people like it.
-
-Hope that next year, Apple can spend some time on Xcode Extensions.  
+    Hope that next year, Apple can spend some time on Xcode Extensions.  
 
 ## Prevent Suggestions Being Committed
 
-Since the suggestions are presented as comments, they are in your code. If you are not careful enough, they can be committed to your git repo. To avoid that, I would recommend adding a pre-commit git hook to prevent this from happening. Maybe later I will add an command for that.
+Since the suggestions are presented as comments, they are in your code. If you are not careful enough, they can be committed to your git repo. To avoid that, I would recommend adding a pre-commit git hook to prevent this from happening.
 
 ```sh
 #!/bin/sh

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ The first time the commands run, the extension will ask for 2 types of permissio
 - Previous Suggestion: If there is more than 1 suggestion, switch to the previous one.
 - Accept Suggestion: Add the suggestion to the code.
 - Reject Suggestion: Remove the suggestion comments.
-- Turn On Real-time Suggestions: When turn on, Copilot will auto-insert suggestion comments to your code while editing. You have to manually turn it on for every open window of Xcode.
+- Turn On Real-time Suggestions: When turn on, Copilot will auto-insert suggestion comments to your code while editing.
 - Turn Off Real-time Suggestions: Turns the real-time suggestions off.
 - Real-time Suggestions: It is an entry point only for Copilot for Xcode. When suggestions are successfully fetched, Copilot for Xcode will run this command to present the suggestions.
 - Prefetch Suggestions: It is an entry point only for Copilot for Xcode. In the background, Copilot for Xcode will occasionally run this command to prefetch real-time suggestions. 
 
 **About real-time suggestions**
 
-- The on/off state is not persisted, they will be reset every time Xcode is quit. (For technical reasons, you always need to run a random command to start the XPCService, it will be confusing if it's persisted.)
+- The on/off state is persisted, make sure you turn it off manually if you no longer want it.
 - The implementation won't feel as smooth as that of VSCode.
   
     The magic behind it is that it will keep calling the command from the menu when you are not typing or clicking the mouse. So it will have to listen to those events, I am not sure if people like it.

--- a/XPCService/main.swift
+++ b/XPCService/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Service
 
 let listener = NSXPCListener(
     machServiceName: Bundle.main.object(forInfoDictionaryKey: "BUNDLE_IDENTIFIER_BASE") as! String
@@ -7,4 +8,5 @@ let listener = NSXPCListener(
 let delegate = ServiceDelegate()
 listener.delegate = delegate
 listener.resume()
+_ = AutoTrigger.shared
 RunLoop.main.run()


### PR DESCRIPTION
In the previous versions the states are not persisted, so users will have to manually turn them back on again when the XPCService is restarted.

Now they are persisted in UserDefaults. And the `AutoTrigger` will now start if Xcode is running and stop when Xcode is terminated.