### PR TITLE
Ignore empty suggestions and fix wrong suggestion comment positions

### DIFF
--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -197,7 +197,8 @@ final class Workspace {
             cursorPosition: cursorPosition,
             tabSize: tabSize,
             indentSize: indentSize,
-            usesTabsForIndentation: usesTabsForIndentation
+            usesTabsForIndentation: usesTabsForIndentation,
+            ignoreSpaceOnlySuggestions: true
         )
 
         guard filespace.suggestionSourceSnapshot == snapshot else { return nil }

--- a/Core/Sources/SuggestionInjector/SuggestionInjector.swift
+++ b/Core/Sources/SuggestionInjector/SuggestionInjector.swift
@@ -82,6 +82,17 @@ public struct SuggestionInjector {
         let commonPrefix = longestCommonPrefix(of: lines[1], and: existedLine ?? "")
 
         if !commonPrefix.isEmpty {
+            let replacingText = {
+                switch (commonPrefix.hasSuffix("\n"), commonPrefix.count) {
+                case (false, let count):
+                    return String(repeating: " ", count: count - 1) + "^"
+                case (true, let count) where count > 1:
+                    return String(repeating: " ", count: count - 2) + "^\n"
+                case (true, _):
+                    return "\n"
+                }
+            }()
+
             lines[1].replaceSubrange(
                 lines[1].startIndex..<(
                     lines[1].index(
@@ -90,18 +101,20 @@ public struct SuggestionInjector {
                         limitedBy: lines[1].endIndex
                     ) ?? lines[1].endIndex
                 ),
-                with: String(repeating: " ", count: commonPrefix.count - 1) + "^"
+                with: replacingText
             )
         }
-        
-        // if the suggestion is only appeding new lines and spaces, return without modification
-        if completion.text.dropFirst(commonPrefix.count).allSatisfy({ $0.isWhitespace || $0.isNewline }) { return }
 
+        // if the suggestion is only appeding new lines and spaces, return without modification
+        if completion.text.dropFirst(commonPrefix.count)
+            .allSatisfy({ $0.isWhitespace || $0.isNewline }) { return }
+
+        // determin if it's inserted to the current line or the next line
         let lineIndex = start.line + {
             guard let existedLine else { return 0 }
             if existedLine.isEmptyOrNewLine { return 1 }
-            if !commonPrefix.isEmpty, commonPrefix.count <= existedLine.count - 1 { return 1 }
-            return 0
+            if commonPrefix.isEmpty { return 0 }
+            return 1
         }()
         if content.endIndex < lineIndex {
             extraInfo.didChangeContent = true
@@ -164,6 +177,7 @@ public struct SuggestionInjector {
 }
 
 extension String {
+    /// Break a string into lines.
     func breakLines(appendLineBreakToLastLine: Bool = false) -> [String] {
         let lines = split(separator: "\n", omittingEmptySubsequences: false)
         var all = [String]()

--- a/Core/Tests/CopilotServiceTests/FetchSuggestionsTests.swift
+++ b/Core/Tests/CopilotServiceTests/FetchSuggestionsTests.swift
@@ -1,0 +1,115 @@
+import LanguageServerProtocol
+import XCTest
+
+@testable import CopilotService
+
+final class FetchSuggestionTests: XCTestCase {
+    func test_process_sugestions_from_server() async throws {
+        struct TestServer: CopilotLSP {
+            func sendRequest<E>(_: E) async throws -> E.Response where E: CopilotRequestType {
+                return CopilotRequest.GetCompletionsCycling.Response(completions: [
+                    .init(
+                        text: "Hello World\n",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 4))),
+                        displayText: "Hello"
+                    ),
+                    .init(
+                        text: " ",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 1))),
+                        displayText: " "
+                    ),
+                    .init(
+                        text: " \n",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 2))),
+                        displayText: " \n"
+                    ),
+                ]) as! E.Response
+            }
+        }
+        let service = CopilotSuggestionService(designatedServer: TestServer())
+        let completions = try await service.getCompletions(
+            fileURL: .init(fileURLWithPath: "/file.swift"),
+            content: "",
+            cursorPosition: .outOfScope,
+            tabSize: 4,
+            indentSize: 4,
+            usesTabsForIndentation: false,
+            ignoreSpaceOnlySuggestions: false
+        )
+        XCTAssertEqual(completions.count, 3)
+    }
+
+    func test_ignore_empty_suggestions() async throws {
+        struct TestServer: CopilotLSP {
+            func sendRequest<E>(_: E) async throws -> E.Response where E: CopilotRequestType {
+                return CopilotRequest.GetCompletionsCycling.Response(completions: [
+                    .init(
+                        text: "Hello World\n",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 4))),
+                        displayText: "Hello"
+                    ),
+                    .init(
+                        text: " ",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 1))),
+                        displayText: " "
+                    ),
+                    .init(
+                        text: " \n",
+                        position: .init((0, 0)),
+                        uuid: "uuid",
+                        range: .init(start: .init((0, 0)), end: .init((0, 2))),
+                        displayText: " \n"
+                    ),
+                ]) as! E.Response
+            }
+        }
+        let service = CopilotSuggestionService(designatedServer: TestServer())
+        let completions = try await service.getCompletions(
+            fileURL: .init(fileURLWithPath: "/file.swift"),
+            content: "",
+            cursorPosition: .outOfScope,
+            tabSize: 4,
+            indentSize: 4,
+            usesTabsForIndentation: false,
+            ignoreSpaceOnlySuggestions: true
+        )
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions.first?.text, "Hello World\n")
+    }
+
+    func test_if_language_identifier_is_unknown_returns_empty_array_immediately() async throws {
+        struct Err: Error, LocalizedError {
+            var errorDescription: String? {
+                "sendRequest Should not be falled"
+            }
+        }
+
+        class TestServer: CopilotLSP {
+            func sendRequest<E>(_: E) async throws -> E.Response where E: CopilotRequestType {
+                throw Err()
+            }
+        }
+        let testServer = TestServer()
+        let service = CopilotSuggestionService(designatedServer: testServer)
+        let completions = try await service.getCompletions(
+            fileURL: .init(fileURLWithPath: "/"),
+            content: "",
+            cursorPosition: .outOfScope,
+            tabSize: 4,
+            indentSize: 4,
+            usesTabsForIndentation: false,
+            ignoreSpaceOnlySuggestions: false
+        )
+        XCTAssertEqual(completions.count, 0)
+    }
+}

--- a/Core/Tests/SuggestionInjectorTests/ProposeSuggestionTests.swift
+++ b/Core/Tests/SuggestionInjectorTests/ProposeSuggestionTests.swift
@@ -186,7 +186,48 @@ final class ProposeSuggestionTests: XCTestCase {
     }
 
     // swiftformat:enable all
-
+    
+    func test_propose_suggestion_overlap_one_line_adding_only_spaces() async throws {
+        let content = """
+        if true {
+            print("hello")
+        } else {
+            print("world")
+        }
+        """
+        let text = "} else {\n"
+        let suggestion = CopilotCompletion(
+            text: text,
+            position: .init(line: 2, character: 0),
+            uuid: "",
+            range: .init(
+                start: .init(line: 2, character: 0),
+                end: .init(line: 2, character: 8)
+            ),
+            displayText: ""
+        )
+        var extraInfo = SuggestionInjector.ExtraInfo()
+        var lines = content.breakLines()
+        SuggestionInjector().proposeSuggestion(
+            intoContentWithoutSuggestion: &lines,
+            completion: suggestion,
+            index: 0,
+            count: 10,
+            extraInfo: &extraInfo
+        )
+        XCTAssertFalse(extraInfo.didChangeContent)
+        XCTAssertFalse(extraInfo.didChangeCursorPosition)
+        XCTAssertNil(extraInfo.suggestionRange)
+        XCTAssertEqual(lines, content.breakLines().applying(extraInfo.modifications))
+        XCTAssertEqual(lines.joined(separator: ""), """
+        if true {
+            print("hello")
+        } else {
+            print("world")
+        }
+        """)
+    }
+    
     func test_propose_suggestion_partial_overlap() async throws {
         let content = "func quickSort() {}}\n"
         let text = """

--- a/Core/Tests/SuggestionInjectorTests/ProposeSuggestionTests.swift
+++ b/Core/Tests/SuggestionInjectorTests/ProposeSuggestionTests.swift
@@ -37,15 +37,19 @@ final class ProposeSuggestionTests: XCTestCase {
         XCTAssertFalse(extraInfo.didChangeCursorPosition)
         XCTAssertEqual(extraInfo.suggestionRange, 2...5)
         XCTAssertEqual(lines, content.breakLines().applying(extraInfo.modifications))
-        XCTAssertEqual(lines.joined(separator: ""), """
-        struct Cat {
+        XCTAssertEqual(
+            lines.joined(separator: ""),
+            """
+            struct Cat {
 
-        /*========== Copilot Suggestion 1/10
-            var name: String
-            var age: String
-        *///======== End of Copilot Suggestion
-        }
-        """)
+            /*========== Copilot Suggestion 1/10
+                var name: String
+                var age: String
+            *///======== End of Copilot Suggestion
+            }
+            """,
+            "The user may want to keep typing on the empty line, so suggestion is addded to the next line"
+        )
     }
 
     func test_propose_suggestion_no_overlap_start_from_previous_line() async throws {
@@ -134,13 +138,57 @@ final class ProposeSuggestionTests: XCTestCase {
         """)
     }
 
+    func test_propose_suggestion_overlap_first_line_is_empty() async throws {
+        let content = """
+        struct Cat {
+            var name: String
+        }
+        """
+        let text = """
+            var name: String
+            var age: String
+        """
+        let suggestion = CopilotCompletion(
+            text: text,
+            position: .init(line: 1, character: 0),
+            uuid: "",
+            range: .init(
+                start: .init(line: 1, character: 0),
+                end: .init(line: 2, character: 18)
+            ),
+            displayText: ""
+        )
+        var extraInfo = SuggestionInjector.ExtraInfo()
+        var lines = content.breakLines()
+        SuggestionInjector().proposeSuggestion(
+            intoContentWithoutSuggestion: &lines,
+            completion: suggestion,
+            index: 0,
+            count: 10,
+            extraInfo: &extraInfo
+        )
+        XCTAssertTrue(extraInfo.didChangeContent)
+        XCTAssertFalse(extraInfo.didChangeCursorPosition)
+        XCTAssertEqual(extraInfo.suggestionRange, 2...5)
+        XCTAssertEqual(lines, content.breakLines().applying(extraInfo.modifications))
+        XCTAssertEqual(lines.joined(separator: ""), """
+        struct Cat {
+            var name: String
+        /*========== Copilot Suggestion 1/10
+                           ^
+            var age: String
+        *///======== End of Copilot Suggestion
+        }
+        """)
+    }
+
     // swiftformat:disable indent trailingSpace
     func test_propose_suggestion_overlap_pure_spaces() async throws {
         let content = """
         func quickSort() {
             
         }
-        """
+        """ // Yes the second line has 4 spaces!
         let text = """
             var array = [1, 3, 2, 4, 5, 6, 7, 8, 9, 10]
             var left = 0
@@ -182,52 +230,11 @@ final class ProposeSuggestionTests: XCTestCase {
             print(array)
         *///======== End of Copilot Suggestion
         }
-        """)
+        """) // Yes the second line still has 4 spaces!
     }
 
     // swiftformat:enable all
-    
-    func test_propose_suggestion_overlap_one_line_adding_only_spaces() async throws {
-        let content = """
-        if true {
-            print("hello")
-        } else {
-            print("world")
-        }
-        """
-        let text = "} else {\n"
-        let suggestion = CopilotCompletion(
-            text: text,
-            position: .init(line: 2, character: 0),
-            uuid: "",
-            range: .init(
-                start: .init(line: 2, character: 0),
-                end: .init(line: 2, character: 8)
-            ),
-            displayText: ""
-        )
-        var extraInfo = SuggestionInjector.ExtraInfo()
-        var lines = content.breakLines()
-        SuggestionInjector().proposeSuggestion(
-            intoContentWithoutSuggestion: &lines,
-            completion: suggestion,
-            index: 0,
-            count: 10,
-            extraInfo: &extraInfo
-        )
-        XCTAssertFalse(extraInfo.didChangeContent)
-        XCTAssertFalse(extraInfo.didChangeCursorPosition)
-        XCTAssertNil(extraInfo.suggestionRange)
-        XCTAssertEqual(lines, content.breakLines().applying(extraInfo.modifications))
-        XCTAssertEqual(lines.joined(separator: ""), """
-        if true {
-            print("hello")
-        } else {
-            print("world")
-        }
-        """)
-    }
-    
+
     func test_propose_suggestion_partial_overlap() async throws {
         let content = "func quickSort() {}}\n"
         let text = """
@@ -274,6 +281,47 @@ final class ProposeSuggestionTests: XCTestCase {
         }
         *///======== End of Copilot Suggestion
 
+        """)
+    }
+
+    func test_propose_suggestion_overlap_one_line_adding_only_spaces() async throws {
+        let content = """
+        if true {
+            print("hello")
+        } else {
+            print("world")
+        }
+        """
+        let text = "} else {\n"
+        let suggestion = CopilotCompletion(
+            text: text,
+            position: .init(line: 2, character: 0),
+            uuid: "",
+            range: .init(
+                start: .init(line: 2, character: 0),
+                end: .init(line: 2, character: 8)
+            ),
+            displayText: ""
+        )
+        var extraInfo = SuggestionInjector.ExtraInfo()
+        var lines = content.breakLines()
+        SuggestionInjector().proposeSuggestion(
+            intoContentWithoutSuggestion: &lines,
+            completion: suggestion,
+            index: 0,
+            count: 10,
+            extraInfo: &extraInfo
+        )
+        XCTAssertFalse(extraInfo.didChangeContent)
+        XCTAssertFalse(extraInfo.didChangeCursorPosition)
+        XCTAssertNil(extraInfo.suggestionRange)
+        XCTAssertEqual(lines, content.breakLines().applying(extraInfo.modifications))
+        XCTAssertEqual(lines.joined(separator: ""), """
+        if true {
+            print("hello")
+        } else {
+            print("world")
+        }
         """)
     }
 }


### PR DESCRIPTION
Fixes #15 

The issue is that empty suggestions are not ignored. Unlike VSCode, where the user can tap enter to accept a suggestion, it feels more natural to just ignore these suggestions in Copilot for Xcode. 

This PR also fixes that suggestion comments may be inserted into the wrong line.