### PR TITLE
Automatically restart XPC service on updates

### DIFF
--- a/Copilot for Xcode.xcodeproj/project.pbxproj
+++ b/Copilot for Xcode.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		C8189B1C2938972F00C9DCDA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8189B1B2938972F00C9DCDA /* ContentView.swift */; };
 		C8189B1E2938973000C9DCDA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8189B1D2938973000C9DCDA /* Assets.xcassets */; };
 		C8189B212938973000C9DCDA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8189B202938973000C9DCDA /* Preview Assets.xcassets */; };
+		C8216B73298036EC00AD38C7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8216B72298036EC00AD38C7 /* main.swift */; };
+		C8216B782980370100AD38C7 /* ReloadLaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8216B772980370100AD38C7 /* ReloadLaunchAgent.swift */; };
+		C8216B7D2980374300AD38C7 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = C8216B7C2980374300AD38C7 /* ArgumentParser */; };
+		C8216B802980378300AD38C7 /* Helper in Embed XPCService */ = {isa = PBXBuildFile; fileRef = C8216B70298036EC00AD38C7 /* Helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C832A47C2940C73E000989F2 /* copilot in Copy LanguageServer for Dev */ = {isa = PBXBuildFile; fileRef = C832A47B2940C71D000989F2 /* copilot */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C832A47D2940C74E000989F2 /* copilot in CopyFiles */ = {isa = PBXBuildFile; fileRef = C832A47B2940C71D000989F2 /* copilot */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C83B2B7A293D9C8C00C5ACCD /* LaunchAgentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83B2B79293D9C8C00C5ACCD /* LaunchAgentManager.swift */; };
@@ -51,6 +55,13 @@
 			remoteGlobalIDString = C814588B2939EFDC00135263;
 			remoteInfo = EditorExtension;
 		};
+		C8216B7E2980377E00AD38C7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8189B0E2938972F00C9DCDA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C8216B6F298036EC00AD38C7;
+			remoteInfo = Helper;
+		};
 		C8520304293CF0D400460097 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C8189B0E2938972F00C9DCDA /* Project object */;
@@ -81,12 +92,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		C8216B6E298036EC00AD38C7 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		C8520306293CF0EF00460097 /* Embed XPCService */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 6;
 			files = (
+				C8216B802980378300AD38C7 /* Helper in Embed XPCService */,
 				C8520307293CF13600460097 /* CopilotForXcodeXPCService in Embed XPCService */,
 			);
 			name = "Embed XPCService";
@@ -151,6 +172,9 @@
 		C8189B222938973000C9DCDA /* Copilot_for_Xcode.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Copilot_for_Xcode.entitlements; sourceTree = "<group>"; };
 		C8189B282938979000C9DCDA /* Core */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Core; sourceTree = "<group>"; };
 		C81E867D296FE4420026E908 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		C8216B70298036EC00AD38C7 /* Helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Helper; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8216B72298036EC00AD38C7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		C8216B772980370100AD38C7 /* ReloadLaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReloadLaunchAgent.swift; sourceTree = "<group>"; };
 		C832A47B2940C71D000989F2 /* copilot */ = {isa = PBXFileReference; lastKnownFileType = folder; name = copilot; path = copilot.vim/copilot; sourceTree = "<group>"; };
 		C83B2B79293D9C8C00C5ACCD /* LaunchAgentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManager.swift; sourceTree = "<group>"; };
 		C83B2B7B293D9FB400C5ACCD /* CopilotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotView.swift; sourceTree = "<group>"; };
@@ -195,6 +219,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C882175A294187E100A22FD3 /* Client in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8216B6D298036EC00AD38C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8216B7D2980374300AD38C7 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +286,7 @@
 				C8189B182938972F00C9DCDA /* Copilot for Xcode */,
 				C81458922939EFDC00135263 /* EditorExtension */,
 				C81458B6293A015C00135263 /* XPCService */,
+				C8216B71298036EC00AD38C7 /* Helper */,
 				C814588D2939EFDC00135263 /* Frameworks */,
 				C8189B172938972F00C9DCDA /* Products */,
 			);
@@ -265,6 +298,7 @@
 				C8189B162938972F00C9DCDA /* Copilot for Xcode Dev.app */,
 				C814588C2939EFDC00135263 /* Copilot.appex */,
 				C81458B5293A015C00135263 /* CopilotForXcodeXPCService */,
+				C8216B70298036EC00AD38C7 /* Helper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -295,6 +329,15 @@
 				C8189B202938973000C9DCDA /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		C8216B71298036EC00AD38C7 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				C8216B72298036EC00AD38C7 /* main.swift */,
+				C8216B772980370100AD38C7 /* ReloadLaunchAgent.swift */,
+			);
+			path = Helper;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -356,6 +399,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C8216B7F2980377E00AD38C7 /* PBXTargetDependency */,
 				C8520305293CF0D400460097 /* PBXTargetDependency */,
 				C814589A2939EFDC00135263 /* PBXTargetDependency */,
 			);
@@ -366,6 +410,26 @@
 			productName = "Copilot for Xcode";
 			productReference = C8189B162938972F00C9DCDA /* Copilot for Xcode Dev.app */;
 			productType = "com.apple.product-type.application";
+		};
+		C8216B6F298036EC00AD38C7 /* Helper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C8216B74298036EC00AD38C7 /* Build configuration list for PBXNativeTarget "Helper" */;
+			buildPhases = (
+				C8216B6C298036EC00AD38C7 /* Sources */,
+				C8216B6D298036EC00AD38C7 /* Frameworks */,
+				C8216B6E298036EC00AD38C7 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Helper;
+			packageProductDependencies = (
+				C8216B7C2980374300AD38C7 /* ArgumentParser */,
+			);
+			productName = Helper;
+			productReference = C8216B70298036EC00AD38C7 /* Helper */;
+			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
@@ -386,6 +450,9 @@
 					C8189B152938972F00C9DCDA = {
 						CreatedOnToolsVersion = 14.1;
 					};
+					C8216B6F298036EC00AD38C7 = {
+						CreatedOnToolsVersion = 14.1;
+					};
 				};
 			};
 			buildConfigurationList = C8189B112938972F00C9DCDA /* Build configuration list for PBXProject "Copilot for Xcode" */;
@@ -397,6 +464,9 @@
 				Base,
 			);
 			mainGroup = C8189B0D2938972F00C9DCDA;
+			packageReferences = (
+				C8216B792980373800AD38C7 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+			);
 			productRefGroup = C8189B172938972F00C9DCDA /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -404,6 +474,7 @@
 				C8189B152938972F00C9DCDA /* Copilot for Xcode */,
 				C814588B2939EFDC00135263 /* EditorExtension */,
 				C81458B4293A015C00135263 /* XPCService */,
+				C8216B6F298036EC00AD38C7 /* Helper */,
 			);
 		};
 /* End PBXProject section */
@@ -471,6 +542,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8216B6C298036EC00AD38C7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8216B73298036EC00AD38C7 /* main.swift in Sources */,
+				C8216B782980370100AD38C7 /* ReloadLaunchAgent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -478,6 +558,11 @@
 			isa = PBXTargetDependency;
 			target = C814588B2939EFDC00135263 /* EditorExtension */;
 			targetProxy = C81458992939EFDC00135263 /* PBXContainerItemProxy */;
+		};
+		C8216B7F2980377E00AD38C7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C8216B6F298036EC00AD38C7 /* Helper */;
+			targetProxy = C8216B7E2980377E00AD38C7 /* PBXContainerItemProxy */;
 		};
 		C8520305293CF0D400460097 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -757,6 +842,32 @@
 			};
 			name = Release;
 		};
+		C8216B75298036EC00AD38C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5YKZ4Y3DAW;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		C8216B76298036EC00AD38C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5YKZ4Y3DAW;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -796,9 +907,34 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C8216B74298036EC00AD38C7 /* Build configuration list for PBXNativeTarget "Helper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8216B75298036EC00AD38C7 /* Debug */,
+				C8216B76298036EC00AD38C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C8216B792980373800AD38C7 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		C8216B7C2980374300AD38C7 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C8216B792980373800AD38C7 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
 		C8821759294187E100A22FD3 /* Client */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Client;

--- a/Copilot for Xcode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Copilot for Xcode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -62,6 +62,15 @@
         "revision" : "29487b6581bb785c372c611c943541ef4309d051",
         "version" : "0.3.1"
       }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
+      }
     }
   ],
   "version" : 2

--- a/Copilot for Xcode/LaunchAgentManager.swift
+++ b/Copilot for Xcode/LaunchAgentManager.swift
@@ -1,84 +1,14 @@
 import Foundation
+import LaunchAgentManager
 
-struct LaunchAgentManager {
-    var serviceIdentifier: String {
-        Bundle.main
-            .object(forInfoDictionaryKey: "BUNDLE_IDENTIFIER_BASE") as! String +
-            ".XPCService"
-    }
-
-    var location: String {
-        Bundle.main.executableURL?.deletingLastPathComponent()
-            .appendingPathComponent("CopilotForXcodeXPCService").path ?? ""
-    }
-
-    var launchAgentDirURL: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents")
-    }
-
-    var launchAgentPath: String {
-        launchAgentDirURL.appendingPathComponent("\(serviceIdentifier).plist").path
-    }
-
-    func setupLaunchAgent() throws {
-        let content = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>RunAtLoad</key>
-                <true/>
-            <key>Label</key>
-                <string>\(serviceIdentifier)</string>
-                <key>Program</key>
-                <string>\(location)</string>
-            <key>MachServices</key>
-            <dict>
-                <key>\(serviceIdentifier)</key>
-                <true/>
-            </dict>
-        </dict>
-        </plist>
-        """
-        if !FileManager.default.fileExists(atPath: launchAgentDirURL.path) {
-            try FileManager.default.createDirectory(
-                at: launchAgentDirURL,
-                withIntermediateDirectories: false
-            )
-        }
-        FileManager.default.createFile(
-            atPath: launchAgentPath,
-            contents: content.data(using: .utf8)
+extension LaunchAgentManager {
+    init() {
+        self.init(
+            serviceIdentifier: Bundle.main
+                .object(forInfoDictionaryKey: "BUNDLE_IDENTIFIER_BASE") as! String +
+                ".XPCService",
+            executablePath: Bundle.main.executableURL?.deletingLastPathComponent()
+                .appendingPathComponent("CopilotForXcodeXPCService").path ?? ""
         )
-        launchctl("load", launchAgentPath)
-    }
-
-    func removeLaunchAgent() throws {
-        launchctl("unload", launchAgentPath)
-        try FileManager.default.removeItem(atPath: launchAgentPath)
-    }
-
-    func restartLaunchAgent() {
-        launchctl("unload", launchAgentPath)
-        launchctl("load", launchAgentPath)
-    }
-}
-
-private func launchctl(_ args: String...) {
-    let task = Process()
-    task.launchPath = "/bin/launchctl"
-    task.arguments = args
-    task.environment = [
-        "PATH": "/usr/bin",
-    ]
-    let outpipe = Pipe()
-    task.standardOutput = outpipe
-    try? task.run()
-    task.waitUntilExit()
-    if let data = try? outpipe.fileHandleForReading.readToEnd(),
-       let text = String(data: data, encoding: .utf8)
-    {
-        print(text)
     }
 }

--- a/Copilot for Xcode/LaunchAgentView.swift
+++ b/Copilot for Xcode/LaunchAgentView.swift
@@ -1,3 +1,4 @@
+import LaunchAgentManager
 import SwiftUI
 import XPCShared
 

--- a/Copilot for Xcode/LaunchAgentView.swift
+++ b/Copilot for Xcode/LaunchAgentView.swift
@@ -14,11 +14,13 @@ struct LaunchAgentView: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Button(action: {
-                        do {
-                            try LaunchAgentManager().setupLaunchAgent()
-                            isDidSetupLaunchAgentAlertPresented = true
-                        } catch {
-                            errorMessage = error.localizedDescription
+                        Task {
+                            do {
+                                try await LaunchAgentManager().setupLaunchAgent()
+                                isDidSetupLaunchAgentAlertPresented = true
+                            } catch {
+                                errorMessage = error.localizedDescription
+                            }
                         }
                     }) {
                         Text("Set Up Launch Agent for XPC Service")
@@ -27,18 +29,20 @@ struct LaunchAgentView: View {
                         .init(
                             title: Text("Finished Launch Agent Setup"),
                             message: Text(
-                                "You may need to restart Xcode to make the extension work."
+                                "Please refresh the Copilot status. (The first refresh may fail)"
                             ),
                             dismissButton: .default(Text("OK"))
                         )
                     }
 
                     Button(action: {
-                        do {
-                            try LaunchAgentManager().removeLaunchAgent()
-                            isDidRemoveLaunchAgentAlertPresented = true
-                        } catch {
-                            errorMessage = error.localizedDescription
+                        Task {
+                            do {
+                                try await LaunchAgentManager().removeLaunchAgent()
+                                isDidRemoveLaunchAgentAlertPresented = true
+                            } catch {
+                                errorMessage = error.localizedDescription
+                            }
                         }
                     }) {
                         Text("Remove Launch Agent")
@@ -51,8 +55,14 @@ struct LaunchAgentView: View {
                     }
 
                     Button(action: {
-                        LaunchAgentManager().restartLaunchAgent()
-                        isDidRestartLaunchAgentAlertPresented = true
+                        Task {
+                            do {
+                                try await LaunchAgentManager().restartLaunchAgent()
+                                isDidRestartLaunchAgentAlertPresented = true
+                            } catch {
+                                errorMessage = error.localizedDescription
+                            }
+                        }
                     }) {
                         Text("Restart XPC Service")
                     }.alert(isPresented: $isDidRestartLaunchAgentAlertPresented) {
@@ -62,15 +72,13 @@ struct LaunchAgentView: View {
                         )
                     }
 
-                    EmptyView()
+                    Spacer()
                         .alert(isPresented: .init(
                             get: { errorMessage != nil },
-                            set: { yes in
-                                if !yes { errorMessage = nil }
-                            }
+                            set: { _ in errorMessage = nil }
                         )) {
                             .init(
-                                title: Text("Failed. Got to the GitHub page for Help"),
+                                title: Text("Failed"),
                                 message: Text(errorMessage ?? "Unknown Error"),
                                 dismissButton: .default(Text("OK"))
                             )

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -9,11 +9,11 @@ let package = Package(
     products: [
         .library(
             name: "Service",
-            targets: ["Service", "SuggestionInjector"]
+            targets: ["Service", "SuggestionInjector", "FileChangeChecker", "LaunchAgentManager"]
         ),
         .library(
             name: "Client",
-            targets: ["CopilotModel", "Client", "XPCShared"]
+            targets: ["CopilotModel", "Client", "XPCShared", "LaunchAgentManager"]
         ),
     ],
     dependencies: [
@@ -60,5 +60,7 @@ let package = Package(
             name: "ServiceTests",
             dependencies: ["Service", "Client", "CopilotService", "SuggestionInjector", "XPCShared"]
         ),
+        .target(name: "FileChangeChecker"),
+        .target(name: "LaunchAgentManager"),
     ]
 )

--- a/Core/Sources/FileChangeChecker/FileChangeChecker.swift
+++ b/Core/Sources/FileChangeChecker/FileChangeChecker.swift
@@ -1,0 +1,39 @@
+import CryptoKit
+import Dispatch
+import Foundation
+
+/// Check that a file is changed.
+public actor FileChangeChecker {
+    let url: URL
+    var checksum: Data?
+
+    public init(fileURL: URL) async {
+        url = fileURL
+        checksum = getChecksum()
+    }
+
+    public func checkIfChanged() -> Bool {
+        guard let newChecksum = getChecksum() else { return false }
+        return newChecksum != checksum
+    }
+
+    func getChecksum() -> Data? {
+        let bufferSize = 16 * 1024
+        guard let file = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? file.close() }
+        var md5 = CryptoKit.Insecure.MD5()
+        while autoreleasepool(invoking: {
+            let data = file.readData(ofLength: bufferSize)
+            if !data.isEmpty {
+                md5.update(data: data)
+                return true // Continue
+            } else {
+                return false // End of file
+            }
+        }) {}
+
+        let data = Data(md5.finalize())
+
+        return data
+    }
+}

--- a/Core/Sources/LaunchAgentManager/LaunchAgentManager.swift
+++ b/Core/Sources/LaunchAgentManager/LaunchAgentManager.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public struct LaunchAgentManager {
+    let serviceIdentifier: String
+    let executablePath: String
+
+    var launchAgentDirURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+    }
+
+    var launchAgentPath: String {
+        launchAgentDirURL.appendingPathComponent("\(serviceIdentifier).plist").path
+    }
+
+    public init(serviceIdentifier: String, executablePath: String) {
+        self.serviceIdentifier = serviceIdentifier
+        self.executablePath = executablePath
+    }
+
+    public func setupLaunchAgent() throws {
+        let content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>RunAtLoad</key>
+                <true/>
+            <key>Label</key>
+                <string>\(serviceIdentifier)</string>
+                <key>Program</key>
+                <string>\(executablePath)</string>
+            <key>MachServices</key>
+            <dict>
+                <key>\(serviceIdentifier)</key>
+                <true/>
+            </dict>
+        </dict>
+        </plist>
+        """
+        if !FileManager.default.fileExists(atPath: launchAgentDirURL.path) {
+            try FileManager.default.createDirectory(
+                at: launchAgentDirURL,
+                withIntermediateDirectories: false
+            )
+        }
+        FileManager.default.createFile(
+            atPath: launchAgentPath,
+            contents: content.data(using: .utf8)
+        )
+        launchctl("load", launchAgentPath)
+    }
+
+    public func removeLaunchAgent() throws {
+        launchctl("unload", launchAgentPath)
+        try FileManager.default.removeItem(atPath: launchAgentPath)
+    }
+
+    public func restartLaunchAgent() {
+        launchctl("unload", launchAgentPath)
+        launchctl("load", launchAgentPath)
+    }
+}
+
+private func launchctl(_ args: String...) {
+    let task = Process()
+    task.launchPath = "/bin/launchctl"
+    task.arguments = args
+    task.environment = [
+        "PATH": "/usr/bin",
+    ]
+    let outpipe = Pipe()
+    task.standardOutput = outpipe
+    try? task.run()
+}

--- a/Core/Sources/LaunchAgentManager/LaunchAgentManager.swift
+++ b/Core/Sources/LaunchAgentManager/LaunchAgentManager.swift
@@ -18,7 +18,7 @@ public struct LaunchAgentManager {
         self.executablePath = executablePath
     }
 
-    public func setupLaunchAgent() throws {
+    public func setupLaunchAgent() async throws {
         let content = """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -48,28 +48,69 @@ public struct LaunchAgentManager {
             atPath: launchAgentPath,
             contents: content.data(using: .utf8)
         )
-        launchctl("load", launchAgentPath)
+        try await launchctl("load", launchAgentPath)
     }
 
-    public func removeLaunchAgent() throws {
-        launchctl("unload", launchAgentPath)
+    public func removeLaunchAgent() async throws {
+        try await launchctl("unload", launchAgentPath)
         try FileManager.default.removeItem(atPath: launchAgentPath)
     }
 
-    public func restartLaunchAgent() {
-        launchctl("unload", launchAgentPath)
-        launchctl("load", launchAgentPath)
+    public func restartLaunchAgent() async throws {
+        try await helper("reload-launch-agent", "--service-identifier", serviceIdentifier)
     }
 }
 
-private func launchctl(_ args: String...) {
+private func process(_ launchPath: String, _ args: [String]) async throws {
     let task = Process()
-    task.launchPath = "/bin/launchctl"
+    task.launchPath = launchPath
     task.arguments = args
     task.environment = [
         "PATH": "/usr/bin",
     ]
     let outpipe = Pipe()
     task.standardOutput = outpipe
-    try? task.run()
+
+    return try await withUnsafeThrowingContinuation { continuation in
+        do {
+            task.terminationHandler = { process in
+                do {
+                    if process.terminationStatus == 0 {
+                        continuation.resume(returning: ())
+                    } else {
+                        if let data = try? outpipe.fileHandleForReading.readToEnd(),
+                           let content = String(data: data, encoding: .utf8)
+                        {
+                            continuation.resume(throwing: E(errorDescription: content))
+                        } else {
+                            continuation.resume(
+                                throwing: E(
+                                    errorDescription: "Unknown error."
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+            try task.run()
+        } catch {
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+private func helper(_ args: String...) async throws {
+    guard let url = Bundle.main.executableURL?
+        .deletingLastPathComponent()
+        .appendingPathComponent("Helper")
+    else { throw E(errorDescription: "Unable to locate Helper.") }
+    return try await process(url.path, args)
+}
+
+private func launchctl(_ args: String...) async throws {
+    return try await process("/bin/launchctl", args)
+}
+
+struct E: Error, LocalizedError {
+    var errorDescription: String?
 }

--- a/Helper/ReloadLaunchAgent.swift
+++ b/Helper/ReloadLaunchAgent.swift
@@ -1,0 +1,53 @@
+import ArgumentParser
+import Foundation
+
+struct ReloadLaunchAgent: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        abstract: "Reload the launch agent"
+    )
+    
+    @Option(name: .long, help: "The service identifier of the service.")
+    var serviceIdentifier: String
+    
+    var launchAgentDirURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+    }
+    
+    var launchAgentPath: String {
+        launchAgentDirURL.appendingPathComponent("\(serviceIdentifier).plist").path
+    }
+    
+    func run() throws {
+        try? launchctl("unload", launchAgentPath)
+        try launchctl("load", launchAgentPath)
+    }
+}
+
+private func launchctl(_ args: String...) throws {
+    return try process("/bin/launchctl", args)
+}
+
+private func process(_ launchPath: String, _ args: [String]) throws {
+    let task = Process()
+    task.launchPath = launchPath
+    task.arguments = args
+    task.environment = [
+        "PATH": "/usr/bin",
+    ]
+    let outpipe = Pipe()
+    task.standardOutput = outpipe
+    try task.run()
+    task.waitUntilExit()
+
+    struct E: Error, LocalizedError {
+        var errorDescription: String?
+    }
+
+    if task.terminationStatus == 0 {
+        return
+    }
+    throw E(
+        errorDescription: "Failed to restart. Please make sure the launch agent is already loaded."
+    )
+}

--- a/Helper/main.swift
+++ b/Helper/main.swift
@@ -1,0 +1,14 @@
+import ArgumentParser
+import Foundation
+
+struct Helper: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "helper",
+        abstract: "Helper CLI for Copilot for Xcode",
+        subcommands: [
+            ReloadLaunchAgent.self
+        ]
+    )
+}
+
+Helper.main()

--- a/README.md
+++ b/README.md
@@ -44,11 +44,19 @@ Or you can add them manually by going to the `Privacy & Security` tab in `System
 - Accessibility API: Click `Accessibility`, and add `Copilot for Xcode.app` to the list.
 - Input Monitoring: Click `Input Monitoring` and add `Copilot for Xcode.app` to the list.
 
+### Alternative Ways to Launch the XPC Service
+
+The launch agent is set to `RunAtLoad`, so it will start when you log on to your computer. If you have a solution to configure the launch agent to start and stop on demand, please file an issue or pull request (note that the XPC service must be started before the user calls any commands, as it needs to call some of the commands proactively to provide real-time suggestions).
+
+Alternatively, you can skip the Launch Agent part and use other applications to watch Xcode launch and then launch the XPC service when needed. The executable is located at `Copilot for Xcode.app/Contents/MacOS/CopilotForXcodeXPCService`. Or you can remove the `RunAtLoad` field from the plist and run it manually.
+
 ## Update 
 
-You can manually download the latest release. After updating the app, don't forget to click `Restart XPC Service` in the app to kill the old version and run the new version. (I will make it auto-restartable later. )
+You can download the latest version manually from the latest [release](https://github.com/intitni/CopilotForXcode/releases).  
 
-If you want to keep track of the new releases, you can watch this repo's releases to get notifications on updates.
+If you are upgrading from a version lower than 0.5.1, don't forget to click `Restart XPC Service` in the application after the update to kill the old version and start the new one.
+
+If you want to keep track of the new releases, you can watch the releases of this repo to get notifications about updates.
 
 ## Commands
 
@@ -59,8 +67,8 @@ If you want to keep track of the new releases, you can watch this repo's release
 - Reject Suggestion: Remove the suggestion comments.
 - Turn On Real-time Suggestions: When turn on, Copilot will auto-insert suggestion comments to your code while editing.
 - Turn Off Real-time Suggestions: Turns the real-time suggestions off.
-- Real-time Suggestions: It is an entry point only for Copilot for Xcode. When suggestions are successfully fetched, Copilot for Xcode will run this command to present the suggestions.
-- Prefetch Suggestions: It is an entry point only for Copilot for Xcode. In the background, Copilot for Xcode will occasionally run this command to prefetch real-time suggestions. 
+- Real-time Suggestions: Call only by Copilot for Xcode. When suggestions are successfully fetched, Copilot for Xcode will run this command to present the suggestions.
+- Prefetch Suggestions: Call only by Copilot for Xcode. In the background, Copilot for Xcode will occasionally run this command to prefetch real-time suggestions. 
 
 **About real-time suggestions**
 

--- a/XPCService/main.swift
+++ b/XPCService/main.swift
@@ -1,12 +1,61 @@
+import AppKit
+import FileChangeChecker
 import Foundation
+import LaunchAgentManager
+import os.log
 import Service
 
-let listener = NSXPCListener(
-    machServiceName: Bundle.main.object(forInfoDictionaryKey: "BUNDLE_IDENTIFIER_BASE") as! String
-        + ".XPCService"
-)
-let delegate = ServiceDelegate()
-listener.delegate = delegate
-listener.resume()
-_ = AutoTrigger.shared
+let bundleIdentifierBase = Bundle.main
+    .object(forInfoDictionaryKey: "BUNDLE_IDENTIFIER_BASE") as! String
+
+let serviceIdentifier = bundleIdentifierBase + ".XPCService"
+
+func setupXPCListener() -> (NSXPCListener, ServiceDelegate) {
+    let listener = NSXPCListener(machServiceName: serviceIdentifier)
+    let delegate = ServiceDelegate()
+    listener.delegate = delegate
+    listener.resume()
+    return (listener, delegate)
+}
+
+func setupAutoTrigger() {
+    _ = AutoTrigger.shared
+}
+
+func setupRestartOnUpdate() {
+    Task {
+        guard let url = Bundle.main.executableURL else { return }
+        let checker = await FileChangeChecker(fileURL: url)
+
+        // If Xcode or Copilot for Xcode is launched, check if the executable of this program is changed.
+        // If changed, restart the launch agent.
+        
+        let sequence = NSWorkspace.shared.notificationCenter
+            .notifications(named: NSWorkspace.didLaunchApplicationNotification)
+        for await notification in sequence {
+            try Task.checkCancellation()
+            guard let app = notification
+                .userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                [
+                    "com.apple.dt.Xcode",
+                    bundleIdentifierBase,
+                ].contains(app.bundleIdentifier)
+            else { continue }
+            guard await checker.checkIfChanged() else {
+                os_log(.info, "XPC Service is not updated, no need to restart.")
+                continue
+            }
+            os_log(.info, "XPC Service will be restarted.")
+            #if DEBUG
+            #else
+            manager.restartLaunchAgent()
+            #endif
+        }
+    }
+}
+
+let xpcListener = setupXPCListener()
+setupAutoTrigger()
+setupRestartOnUpdate()
+os_log(.info, "XPC Service started.")
 RunLoop.main.run()

--- a/XPCService/main.swift
+++ b/XPCService/main.swift
@@ -27,9 +27,10 @@ func setupRestartOnUpdate() {
         guard let url = Bundle.main.executableURL else { return }
         let checker = await FileChangeChecker(fileURL: url)
 
-        // If Xcode or Copilot for Xcode is launched, check if the executable of this program is changed.
+        // If Xcode or Copilot for Xcode is launched, check if the executable of this program is
+        // changed.
         // If changed, restart the launch agent.
-        
+
         let sequence = NSWorkspace.shared.notificationCenter
             .notifications(named: NSWorkspace.didLaunchApplicationNotification)
         for await notification in sequence {
@@ -48,7 +49,15 @@ func setupRestartOnUpdate() {
             os_log(.info, "XPC Service will be restarted.")
             #if DEBUG
             #else
-            manager.restartLaunchAgent()
+            let manager = LaunchAgentManager(
+                serviceIdentifier: serviceIdentifier,
+                executablePath: Bundle.main.executablePath ?? ""
+            )
+            do {
+                try await manager.restartLaunchAgent()
+            } catch {
+                os_log(.error, "XPC Service failed to restart. %{public}s", error.localizedDescription)
+            }
             #endif
         }
     }


### PR DESCRIPTION
Whenever Xcode or Copilot for Xcode is launched, The XPC Service will check if the executable is changed by comparing the md5 of the file.

If changed, it will restart the launch agent.