### PR TITLE
Add PseudoCommandHandler

### DIFF
--- a/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
+++ b/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
@@ -1,10 +1,40 @@
 import AppKit
 import SuggestionWidget
+import Environment
 
 @MainActor
 public final class GraphicalUserInterfaceController {
     public nonisolated static let shared = GraphicalUserInterfaceController()
     nonisolated let realtimeSuggestionIndicatorController = RealtimeSuggestionIndicatorController()
     nonisolated let suggestionWidget = SuggestionWidgetController()
-    private nonisolated init() {}
+    private nonisolated init() {
+        Task { @MainActor in
+            suggestionWidget.onNextButtonTapped = {
+                Task { @ServiceActor in
+                    let handler = PseudoCommandHandler()
+                    await handler.presentNextSuggestion()
+                }
+            }
+            
+            suggestionWidget.onPreviousButtonTapped = {
+                Task { @ServiceActor in
+                    let handler = PseudoCommandHandler()
+                    await handler.presentPreviousSuggestion()
+                }
+            }
+            
+            suggestionWidget.onRejectButtonTapped = {
+                Task { @ServiceActor in
+                    let handler = PseudoCommandHandler()
+                    await handler.rejectSuggestions()
+                }
+            }
+            
+            suggestionWidget.onAcceptButtonTapped = {
+                Task {
+                    try await Environment.triggerAction("Accept Suggestion")
+                }
+            }
+        }
+    }
 }

--- a/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
@@ -14,12 +14,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
         try await workspace.generateSuggestions(
             forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines,
-            cursorPosition: editor.cursorPosition,
-            tabSize: editor.tabSize,
-            indentSize: editor.indentSize,
-            usesTabsForIndentation: editor.usesTabsForIndentation
+            editor: editor
         )
 
         let presenter = PresentInCommentSuggestionPresenter()
@@ -36,11 +31,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, filespace) = try await Workspace
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.selectNextSuggestion(
-            forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines
-        )
+        workspace.selectNextSuggestion(forFileAt: fileURL)
 
         let presenter = PresentInCommentSuggestionPresenter()
         return try await presenter.presentSuggestion(
@@ -56,11 +47,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, filespace) = try await Workspace
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.selectPreviousSuggestion(
-            forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines
-        )
+        workspace.selectPreviousSuggestion(forFileAt: fileURL)
 
         let presenter = PresentInCommentSuggestionPresenter()
         return try await presenter.presentSuggestion(
@@ -76,7 +63,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, filespace) = try await Workspace
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.rejectSuggestion(forFileAt: fileURL)
+        workspace.rejectSuggestion(forFileAt: fileURL, editor: editor)
 
         let presenter = PresentInCommentSuggestionPresenter()
         return try await presenter.discardSuggestion(
@@ -92,7 +79,10 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, _) = try await Workspace.fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
 
-        guard let acceptedSuggestion = workspace.acceptSuggestion(forFileAt: fileURL)
+        guard let acceptedSuggestion = workspace.acceptSuggestion(
+            forFileAt: fileURL,
+            editor: editor
+        )
         else { return nil }
 
         let injector = SuggestionInjector()
@@ -168,12 +158,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
 
         let suggestions = try await workspace.generateSuggestions(
             forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines,
-            cursorPosition: editor.cursorPosition,
-            tabSize: editor.tabSize,
-            indentSize: editor.indentSize,
-            usesTabsForIndentation: editor.usesTabsForIndentation
+            editor: editor
         )
 
         try Task.checkCancellation()

--- a/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
@@ -1,0 +1,147 @@
+import ActiveApplicationMonitor
+import AppKit
+import CopilotModel
+import Environment
+import SuggestionInjector
+import XPCShared
+
+/// It's used to run some commands without really triggering the menu bar item.
+///
+/// For example, we can use it to generate real-time suggestions without Apple Scripts.
+struct PseudoCommandHandler {
+    func presentPreviousSuggestion() async {
+        let handler = WindowBaseCommandHandler()
+        _ = try? await handler.presentPreviousSuggestion(editor: .init(
+            content: "",
+            lines: [],
+            uti: "",
+            cursorPosition: .outOfScope,
+            tabSize: 0,
+            indentSize: 0,
+            usesTabsForIndentation: false
+        ))
+    }
+
+    func presentNextSuggestion() async {
+        let handler = WindowBaseCommandHandler()
+        _ = try? await handler.presentNextSuggestion(editor: .init(
+            content: "",
+            lines: [],
+            uti: "",
+            cursorPosition: .outOfScope,
+            tabSize: 0,
+            indentSize: 0,
+            usesTabsForIndentation: false
+        ))
+    }
+
+    func generateRealtimeSuggestions() async {
+        guard let editor = await getEditorContent() else {
+            try? await Environment.triggerAction("Prefetch Suggestions")
+            return
+        }
+        let mode = PresentationMode(
+            rawValue: UserDefaults.shared
+                .integer(forKey: SettingsKey.suggestionPresentationMode)
+        ) ?? .comment
+        let handler: SuggestionCommandHandler = {
+            switch mode {
+            case .comment:
+                return CommentBaseCommandHandler()
+            case .floatingWidget:
+                return WindowBaseCommandHandler()
+            }
+        }()
+        _ = try? await handler.generateRealtimeSuggestions(editor: editor)
+    }
+
+    func rejectSuggestions() async {
+        let handler = WindowBaseCommandHandler()
+        _ = try? await handler.rejectSuggestion(editor: .init(
+            content: "",
+            lines: [],
+            uti: "",
+            cursorPosition: .outOfScope,
+            tabSize: 0,
+            indentSize: 0,
+            usesTabsForIndentation: false
+        ))
+    }
+}
+
+private extension PseudoCommandHandler {
+    func getFileContent() async -> (String, [String], CursorPosition)? {
+        guard let xcode = ActiveApplicationMonitor.activeXcode else { return nil }
+        let application = AXUIElementCreateApplication(xcode.processIdentifier)
+        guard let focusElement = application.focusedElement,
+              focusElement.description == "Source Editor"
+        else { return nil }
+        guard let selectionRange = focusElement.selectedTextRange else { return nil }
+        let content = focusElement.value
+        let split = content.breakLines()
+        let selectedPosition = selectionRange.upperBound
+        // find row and col from content at selected position
+        var rowIndex = 0
+        var count = 0
+        var colIndex = 0
+        for (i, row) in split.enumerated() {
+            if count + row.count > selectedPosition {
+                rowIndex = i
+                colIndex = selectedPosition - count
+                break
+            }
+            count += row.count
+        }
+        return (content, split, CursorPosition(line: rowIndex, character: colIndex))
+    }
+
+    func getFileURL() async -> URL? {
+        try? await Environment.fetchCurrentFileURL()
+    }
+
+    @ServiceActor
+    func getFilespace() async -> Filespace? {
+        guard let fileURL = await getFileURL() else { return nil }
+        for (_, workspace) in workspaces {
+            if let space = workspace.filespaces[fileURL] { return space }
+        }
+        return nil
+    }
+
+    @ServiceActor
+    func getEditorContent() async -> EditorContent? {
+        guard
+            let filespace = await getFilespace(),
+            let uti = filespace.uti,
+            let tabSize = filespace.tabSize,
+            let indentSize = filespace.indentSize,
+            let usesTabsForIndentation = filespace.usesTabsForIndentation,
+            let content = await getFileContent()
+        else { return nil }
+        return .init(
+            content: content.0,
+            lines: content.1,
+            uti: uti,
+            cursorPosition: content.2,
+            tabSize: tabSize,
+            indentSize: indentSize,
+            usesTabsForIndentation: usesTabsForIndentation
+        )
+    }
+}
+
+public extension String {
+    /// Break a string into lines.
+    func breakLines() -> [String] {
+        let lines = split(separator: "\n", omittingEmptySubsequences: false)
+        var all = [String]()
+        for (index, line) in lines.enumerated() {
+            if index == lines.endIndex - 1 {
+                all.append(String(line))
+            } else {
+                all.append(String(line) + "\n")
+            }
+        }
+        return all
+    }
+}

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -48,12 +48,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
 
         try await workspace.generateSuggestions(
             forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines,
-            cursorPosition: editor.cursorPosition,
-            tabSize: editor.tabSize,
-            indentSize: editor.indentSize,
-            usesTabsForIndentation: editor.usesTabsForIndentation
+            editor: editor
         )
 
         if let suggestion = filespace.presentingSuggestion {
@@ -82,11 +77,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, filespace) = try await Workspace
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.selectNextSuggestion(
-            forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines
-        )
+        workspace.selectNextSuggestion(forFileAt: fileURL)
 
         if let suggestion = filespace.presentingSuggestion {
             presenter.presentSuggestion(
@@ -114,11 +105,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, filespace) = try await Workspace
             .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.selectPreviousSuggestion(
-            forFileAt: fileURL,
-            content: editor.content,
-            lines: editor.lines
-        )
+        workspace.selectPreviousSuggestion(forFileAt: fileURL)
 
         if let suggestion = filespace.presentingSuggestion {
             presenter.presentSuggestion(
@@ -145,7 +132,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         defer { presenter.markAsProcessing(false) }
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, _) = try await Workspace.fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-        workspace.rejectSuggestion(forFileAt: fileURL)
+        workspace.rejectSuggestion(forFileAt: fileURL, editor: editor)
         presenter.discardSuggestion(fileURL: fileURL)
     }
 

--- a/Core/Sources/SuggestionWidget/SuggestionPanelView.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelView.swift
@@ -9,18 +9,31 @@ final class SuggestionPanelViewModel: ObservableObject {
     @Published var suggestionCount: Int
     @Published var currentSuggestionIndex: Int
 
+    var onAcceptButtonTapped: (() -> Void)?
+    var onRejectButtonTapped: (() -> Void)?
+    var onPreviousButtonTapped: (() -> Void)?
+    var onNextButtonTapped: (() -> Void)?
+
     public init(
         startLineIndex: Int = 0,
         suggestion: [String] = [],
         isPanelDisplayed: Bool = false,
         suggestionCount: Int = 0,
-        currentSuggestionIndex: Int = 0
+        currentSuggestionIndex: Int = 0,
+        onAcceptButtonTapped: (() -> Void)? = nil,
+        onRejectButtonTapped: (() -> Void)? = nil,
+        onPreviousButtonTapped: (() -> Void)? = nil,
+        onNextButtonTapped: (() -> Void)? = nil
     ) {
         self.startLineIndex = startLineIndex
         self.suggestion = suggestion
         self.isPanelDisplayed = isPanelDisplayed
         self.suggestionCount = suggestionCount
         self.currentSuggestionIndex = currentSuggestionIndex
+        self.onAcceptButtonTapped = onAcceptButtonTapped
+        self.onRejectButtonTapped = onRejectButtonTapped
+        self.onPreviousButtonTapped = onPreviousButtonTapped
+        self.onNextButtonTapped = onNextButtonTapped
     }
 }
 
@@ -107,7 +120,7 @@ struct CodeBlock: View {
         }))
     }
 }
-        
+
 struct ToolBar: View {
     @ObservedObject var viewModel: SuggestionPanelViewModel
 
@@ -115,27 +128,39 @@ struct ToolBar: View {
         HStack {
             Button(action: {
                 Task {
+                    if let block = viewModel.onPreviousButtonTapped {
+                        block()
+                        return
+                    }
                     try await Environment.triggerAction("Previous Suggestion")
                 }
             }) {
                 Image(systemName: "chevron.left")
             }.buttonStyle(.plain)
-            
+
             Text("\(viewModel.currentSuggestionIndex + 1) / \(viewModel.suggestionCount)")
                 .monospacedDigit()
-            
+
             Button(action: {
                 Task {
+                    if let block = viewModel.onNextButtonTapped {
+                        block()
+                        return
+                    }
                     try await Environment.triggerAction("Next Suggestion")
                 }
             }) {
-                Image(systemName: "chevron.right")     
+                Image(systemName: "chevron.right")
             }.buttonStyle(.plain)
 
             Spacer()
 
             Button(action: {
                 Task {
+                    if let block = viewModel.onRejectButtonTapped {
+                        block()
+                        return
+                    }
                     try await Environment.triggerAction("Reject Suggestion")
                 }
             }) {
@@ -144,6 +169,10 @@ struct ToolBar: View {
 
             Button(action: {
                 Task {
+                    if let block = viewModel.onAcceptButtonTapped {
+                        block()
+                        return
+                    }
                     try await Environment.triggerAction("Accept Suggestion")
                 }
             }) {

--- a/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
@@ -70,6 +70,26 @@ public final class SuggestionWidgetController {
     private var xcode: NSRunningApplication?
     private var suggestionForFiles: [URL: Suggestion] = [:]
 
+    public var onAcceptButtonTapped: (() -> Void)? {
+        get { suggestionPanelViewModel.onAcceptButtonTapped }
+        set { suggestionPanelViewModel.onAcceptButtonTapped = newValue }
+    }
+
+    public var onRejectButtonTapped: (() -> Void)? {
+        get { suggestionPanelViewModel.onRejectButtonTapped }
+        set { suggestionPanelViewModel.onRejectButtonTapped = newValue }
+    }
+
+    public var onPreviousButtonTapped: (() -> Void)? {
+        get { suggestionPanelViewModel.onPreviousButtonTapped }
+        set { suggestionPanelViewModel.onPreviousButtonTapped = newValue }
+    }
+
+    public var onNextButtonTapped: (() -> Void)? {
+        get { suggestionPanelViewModel.onNextButtonTapped }
+        set { suggestionPanelViewModel.onNextButtonTapped = newValue }
+    }
+
     enum Suggestion {
         case code([String], startLineIndex: Int, currentSuggestionIndex: Int, suggestionCount: Int)
     }


### PR DESCRIPTION
The prefetch suggestions command may still cause the editor to become blocked, so I have implemented a temporary workaround.

Instead of directly calling the command using Apple Script, it now first verifies whether there is sufficient information to create an `EditorContent`. If there is, it will call the other command handlers directly; otherwise, it will fall back to using Apple Script.

The necessary information can be retrieved either from the cache of another command or through the Accessibility API.

Another advantage of this approach is that the `PseudoCommandHandler` can also be utilized in the suggestion panel buttons.