### PR TITLE
Add syntax highlighting

### DIFF
--- a/Copilot for Xcode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Copilot for Xcode.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr",
+      "state" : {
+        "revision" : "93199b9e434f04bda956a613af8f571933f9f037",
+        "version" : "2.1.2"
+      }
+    },
+    {
       "identity" : "jsonrpc",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/JSONRPC",
@@ -61,6 +70,15 @@
       "state" : {
         "revision" : "29487b6581bb785c372c611c943541ef4309d051",
         "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "splash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/Splash",
+      "state" : {
+        "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -25,6 +25,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ChimeHQ/LanguageClient", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "0.1.0"),
+        .package(url: "https://github.com/raspu/Highlightr", from: "2.1.0"),
+        .package(url: "https://github.com/JohnSundell/Splash", from: "0.1.0"),
     ],
     targets: [
         .target(name: "CGEventObserver"),
@@ -102,6 +104,8 @@ let package = Package(
                 "ActiveApplicationMonitor",
                 "AXNotificationStream",
                 "Environment",
+                "Highlightr",
+                "Splash",
             ]
         ),
         .target(name: "UpdateChecker"),

--- a/Core/Sources/CopilotService/LanguageIdentifierFromFilePath.swift
+++ b/Core/Sources/CopilotService/LanguageIdentifierFromFilePath.swift
@@ -219,7 +219,7 @@ let fileExtensionToLanguageId = {
     return dict
 }()
 
-func languageIdentifierFromFileURL(_ fileURL: URL) -> LanguageIdentifier? {
+public func languageIdentifierFromFileURL(_ fileURL: URL) -> LanguageIdentifier? {
     let fileExtension = fileURL.pathExtension
     return fileExtensionToLanguageId[fileExtension]
 }

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -1,4 +1,5 @@
 import CopilotModel
+import CopilotService
 import Environment
 import Foundation
 import os.log
@@ -55,6 +56,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
             presenter.presentSuggestion(
                 suggestion,
                 lines: editor.lines,
+                language: filespace.language,
                 fileURL: fileURL,
                 currentSuggestionIndex: filespace.suggestionIndex,
                 suggestionCount: filespace.suggestions.count
@@ -83,6 +85,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
             presenter.presentSuggestion(
                 suggestion,
                 lines: editor.lines,
+                language: filespace.language,
                 fileURL: fileURL,
                 currentSuggestionIndex: filespace.suggestionIndex,
                 suggestionCount: filespace.suggestions.count
@@ -111,6 +114,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
             presenter.presentSuggestion(
                 suggestion,
                 lines: editor.lines,
+                language: filespace.language,
                 fileURL: fileURL,
                 currentSuggestionIndex: filespace.suggestionIndex,
                 suggestionCount: filespace.suggestions.count

--- a/Core/Sources/Service/SuggestionPresenter/PresentInWindowSuggestionPresenter.swift
+++ b/Core/Sources/Service/SuggestionPresenter/PresentInWindowSuggestionPresenter.swift
@@ -5,6 +5,7 @@ struct PresentInWindowSuggestionPresenter {
     func presentSuggestion(
         _ suggestion: CopilotCompletion,
         lines: [String],
+        language: String,
         fileURL: URL,
         currentSuggestionIndex: Int,
         suggestionCount: Int
@@ -13,6 +14,7 @@ struct PresentInWindowSuggestionPresenter {
             let controller = GraphicalUserInterfaceController.shared.suggestionWidget
             controller.suggestCode(
                 suggestion.text,
+                language: language,
                 startLineIndex: suggestion.position.line,
                 fileURL: fileURL,
                 currentSuggestionIndex: currentSuggestionIndex,

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -13,6 +13,7 @@ final class Filespace {
     }
 
     let fileURL: URL
+    private(set) lazy var language: String = languageIdentifierFromFileURL(fileURL)?.rawValue ?? "plaintext"
     var suggestions: [CopilotCompletion] = [] {
         didSet { lastSuggestionUpdateTime = Environment.now() }
     }

--- a/Core/Sources/SuggestionWidget/SuggestionPanelView.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @MainActor
 final class SuggestionPanelViewModel: ObservableObject {
     @Published var startLineIndex: Int
-    @Published var suggestion: [String]
+    @Published var suggestion: [NSAttributedString]
     @Published var isPanelDisplayed: Bool
     @Published var suggestionCount: Int
     @Published var currentSuggestionIndex: Int
@@ -16,7 +16,7 @@ final class SuggestionPanelViewModel: ObservableObject {
 
     public init(
         startLineIndex: Int = 0,
-        suggestion: [String] = [],
+        suggestion: [NSAttributedString] = [],
         isPanelDisplayed: Bool = false,
         suggestionCount: Int = 0,
         currentSuggestionIndex: Int = 0,
@@ -41,6 +41,7 @@ struct SuggestionPanelView: View {
     @ObservedObject var viewModel: SuggestionPanelViewModel
     @State var isHovering: Bool = false
     @State var codeHeight: Double = 0
+    let backgroundColor = #colorLiteral(red: 0.1580096483, green: 0.1730263829, blue: 0.2026666105, alpha: 1)
 
     var body: some View {
         VStack {
@@ -53,7 +54,7 @@ struct SuggestionPanelView: View {
                     ScrollView {
                         CodeBlock(viewModel: viewModel)
                     }
-                    .background(Color(red: 31 / 255, green: 31 / 255, blue: 36 / 255))
+                    .background(Color(nsColor: backgroundColor))
 
                     ToolBar(viewModel: viewModel)
                 }
@@ -106,7 +107,7 @@ struct CodeBlock: View {
             ForEach(0..<viewModel.suggestion.count, id: \.self) { index in
                 Text("\(index + viewModel.startLineIndex + 1)")
                     .foregroundColor(Color.white.opacity(0.6))
-                Text(viewModel.suggestion[index])
+                Text(AttributedString(viewModel.suggestion[index]))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .multilineTextAlignment(.leading)
                     .lineSpacing(4)
@@ -210,16 +211,17 @@ struct SuggestionPanelView_Preview: PreviewProvider {
         SuggestionPanelView(viewModel: .init(
             startLineIndex: 8,
             suggestion:
-            """
-            LazyVGrid(columns: [GridItem(.fixed(30)), GridItem(.flexible())]) {
+            highlighted(
+                code: """
+                LazyVGrid(columns: [GridItem(.fixed(30)), GridItem(.flexible())]) {
                 ForEach(0..<viewModel.suggestion.count, id: \\.self) { index in // lkjaskldjalksjdlkasjdlkajslkdjas
                     Text(viewModel.suggestion[index])
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .multilineTextAlignment(.leading)
                 }
-                Spacer()
-            }
-            """.split(separator: "\n").map(String.init),
+                """,
+                language: "swift"
+            ),
             isPanelDisplayed: true
         ))
         .frame(width: 450, height: 400)

--- a/Core/Sources/SuggestionWidget/WidgetView.swift
+++ b/Core/Sources/SuggestionWidget/WidgetView.swift
@@ -109,7 +109,7 @@ struct WidgetView_Preview: PreviewProvider {
 
             WidgetView(
                 viewModel: .init(isProcessing: false),
-                panelViewModel: .init(suggestion: ["Hello"]),
+                panelViewModel: .init(suggestion: [.init(string: "Hello")]),
                 isHovering: false
             )
         }


### PR DESCRIPTION
Splash is good at Swift, but it's not providing builtin support for other languages. Highlightr uses highlight.js, which is terrible in highlighting Swift. Hope someone can make a wrapper for prism.js.

So Splash will be used for Swift, and Highlightr will be used for other languages. The color scheme used is One Dark.