### PR TITLE
Cache filespace info automatically on file change

### DIFF
--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -168,7 +168,20 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
     }
 
     func presentRealtimeSuggestions(editor: EditorContent) async throws -> UpdatedContent? {
-        // not needed.
+        Task {
+            try? await prepareCache(editor: editor)
+        }
+        return nil
+    }
+    
+    func prepareCache(editor: EditorContent) async throws -> UpdatedContent? {
+        let fileURL = try await Environment.fetchCurrentFileURL()
+        let (_, filespace) = try await Workspace
+            .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
+        filespace.uti = editor.uti
+        filespace.tabSize = editor.tabSize
+        filespace.indentSize = editor.indentSize
+        filespace.usesTabsForIndentation = editor.usesTabsForIndentation
         return nil
     }
 


### PR DESCRIPTION
In previous versions, the real-time suggestion has to run via Apple Script at least once to cache some information for later use. That will block the editor and dismiss the completion panel.

Now we trigger the unused "Real-time Suggestions" command when the focused element changes to pre-cache the info.