### PR TITLE
Stop presenting LSP ServerErrors to the widget

### DIFF
--- a/Core/Sources/Logger/Logger.swift
+++ b/Core/Sources/Logger/Logger.swift
@@ -33,7 +33,7 @@ public final class Logger {
         }
 
         let osLog = OSLog(subsystem: subsystem, category: category)
-        os_log("%@", log: osLog, type: osLogType, message as CVarArg)
+        os_log("%{public}@", log: osLog, type: osLogType, message as CVarArg)
     }
 
     public func debug(_ message: String) {

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -7,6 +7,7 @@ import OpenAIService
 import SuggestionInjector
 import SuggestionWidget
 import XPCShared
+import LanguageServerProtocol
 
 @ServiceActor
 struct WindowBaseCommandHandler: SuggestionCommandHandler {
@@ -18,6 +19,8 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         Task {
             do {
                 try await _presentSuggestions(editor: editor)
+            } catch let error as ServerError {
+                Logger.service.error(error)
             } catch {
                 presenter.presentError(error)
                 Logger.service.error(error)


### PR DESCRIPTION
These errors are not very helpful but very annoying. Anyone interested in these errors can still find them in the Console.app