### PR TITLE
Accept suggestion via Accessibility API in widget

### DIFF
--- a/Copilot for Xcode/SettingsView.swift
+++ b/Copilot for Xcode/SettingsView.swift
@@ -15,6 +15,8 @@ final class Settings: ObservableObject {
     var suggestionWidgetPositionMode: SuggestionWidgetPositionMode
     @AppStorage(\.widgetColorScheme)
     var widgetColorScheme: WidgetColorScheme
+    @AppStorage(\.acceptSuggestionWithAccessibilityAPI)
+    var acceptSuggestionWithAccessibilityAPI: Bool
     init() {}
 }
 
@@ -107,6 +109,11 @@ struct SettingsView: View {
                             .fill(Color.white.opacity(0.2))
                     )
                 }
+                
+                Toggle(isOn: $settings.acceptSuggestionWithAccessibilityAPI) {
+                    Text("Use accessibility API to accept suggestion in widget")
+                }
+                .toggleStyle(.switch)
             }
         }.buttonStyle(.copilot)
     }

--- a/Core/Sources/Preferences/Keys.swift
+++ b/Core/Sources/Preferences/Keys.swift
@@ -100,6 +100,15 @@ public struct UserDefaultPreferenceKeys {
 
     public var chatGPTLanguage: ChatGPTLanguage { .init() }
 
+    public struct AcceptSuggestionWithAccessibilityAPI: UserDefaultPreferenceKey {
+        public let defaultValue = false
+        public let key = "AcceptSuggestionWithAccessibilityAPI"
+    }
+
+    public var acceptSuggestionWithAccessibilityAPI: AcceptSuggestionWithAccessibilityAPI {
+        .init()
+    }
+
     public var disableLazyVStack: FeatureFlags.DisableLazyVStack { .init() }
 }
 

--- a/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
+++ b/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
@@ -31,8 +31,9 @@ public final class GraphicalUserInterfaceController {
             }
 
             suggestionWidget.onAcceptButtonTapped = {
-                Task {
-                    try await Environment.triggerAction("Accept Suggestion")
+                Task { @ServiceActor in
+                    let handler = PseudoCommandHandler()
+                    await handler.acceptSuggestion()
                 }
             }
         }

--- a/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
@@ -70,63 +70,67 @@ struct PseudoCommandHandler {
     }
 
     func acceptSuggestion() async {
-        do {
-            try await Environment.triggerAction("Accept Suggestion")
-            return
-        } catch {
-            PresentInWindowSuggestionPresenter().presentError(error)
-        }
-        guard let xcode = ActiveApplicationMonitor.activeXcode else { return }
-        let application = AXUIElementCreateApplication(xcode.processIdentifier)
-        guard let focusElement = application.focusedElement,
-              focusElement.description == "Source Editor"
-        else { return }
-        guard let (content, lines, cursorPosition) = await getFileContent() else {
-            PresentInWindowSuggestionPresenter().presentErrorMessage("Unable to get file content.")
-            return
-        }
-        let handler = CommentBaseCommandHandler()
-        do {
-            guard let result = try await handler.acceptSuggestion(editor: .init(
-                content: content,
-                lines: lines,
-                uti: "",
-                cursorPosition: cursorPosition,
-                selections: [],
-                tabSize: 0,
-                indentSize: 0,
-                usesTabsForIndentation: false
-            )) else { return }
-
-            let oldPosition = focusElement.selectedTextRange
-
-            let error = AXUIElementSetAttributeValue(
-                focusElement,
-                kAXValueAttribute as CFString,
-                result.content as CFTypeRef
-            )
-
-            if error != AXError.success {
+        if UserDefaults.shared.value(for: \.acceptSuggestionWithAccessibilityAPI) {
+            guard let xcode = ActiveApplicationMonitor.activeXcode else { return }
+            let application = AXUIElementCreateApplication(xcode.processIdentifier)
+            guard let focusElement = application.focusedElement,
+                  focusElement.description == "Source Editor"
+            else { return }
+            guard let (content, lines, cursorPosition) = await getFileContent() else {
                 PresentInWindowSuggestionPresenter()
-                    .presentErrorMessage("Fail to set editor content.")
+                    .presentErrorMessage("Unable to get file content.")
+                return
             }
+            let handler = CommentBaseCommandHandler()
+            do {
+                guard let result = try await handler.acceptSuggestion(editor: .init(
+                    content: content,
+                    lines: lines,
+                    uti: "",
+                    cursorPosition: cursorPosition,
+                    selections: [],
+                    tabSize: 0,
+                    indentSize: 0,
+                    usesTabsForIndentation: false
+                )) else { return }
 
-            if let oldPosition {
-                var range = CFRange(
-                    location: oldPosition.lowerBound,
-                    length: oldPosition.upperBound
+                let oldPosition = focusElement.selectedTextRange
+
+                let error = AXUIElementSetAttributeValue(
+                    focusElement,
+                    kAXValueAttribute as CFString,
+                    result.content as CFTypeRef
                 )
-                if let value = AXValueCreate(.cfRange, &range) {
-                    AXUIElementSetAttributeValue(
-                        focusElement,
-                        kAXSelectedTextRangeAttribute as CFString,
-                        value
-                    )
-                }
-            }
 
-        } catch {
-            PresentInWindowSuggestionPresenter().presentError(error)
+                if error != AXError.success {
+                    PresentInWindowSuggestionPresenter()
+                        .presentErrorMessage("Fail to set editor content.")
+                }
+
+                if let oldPosition {
+                    var range = CFRange(
+                        location: oldPosition.lowerBound,
+                        length: 0
+                    )
+                    if let value = AXValueCreate(.cfRange, &range) {
+                        AXUIElementSetAttributeValue(
+                            focusElement,
+                            kAXSelectedTextRangeAttribute as CFString,
+                            value
+                        )
+                    }
+                }
+
+            } catch {
+                PresentInWindowSuggestionPresenter().presentError(error)
+            }
+        } else {
+            do {
+                try await Environment.triggerAction("Accept Suggestion")
+                return
+            } catch {
+                PresentInWindowSuggestionPresenter().presentError(error)
+            }
         }
     }
 }

--- a/Core/Sources/Service/SuggestionPresenter/PresentInWindowSuggestionPresenter.swift
+++ b/Core/Sources/Service/SuggestionPresenter/PresentInWindowSuggestionPresenter.swift
@@ -47,6 +47,13 @@ struct PresentInWindowSuggestionPresenter {
         }
     }
     
+    func presentErrorMessage(_ message: String) {
+        Task { @MainActor in
+            let controller = GraphicalUserInterfaceController.shared.suggestionWidget
+            controller.presentError(message)
+        }
+    }
+    
     func closeChatRoom(fileURL: URL) {
         Task { @MainActor in
             let controller = GraphicalUserInterfaceController.shared.suggestionWidget

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -118,10 +118,12 @@ extension Workspace {
             filespaces[fileURL] = filespace
         }
 
-        filespace.uti = editor.uti
-        filespace.tabSize = editor.tabSize
-        filespace.indentSize = editor.indentSize
-        filespace.usesTabsForIndentation = editor.usesTabsForIndentation
+        if !editor.uti.isEmpty {
+            filespace.uti = editor.uti
+            filespace.tabSize = editor.tabSize
+            filespace.indentSize = editor.indentSize
+            filespace.usesTabsForIndentation = editor.usesTabsForIndentation
+        }
 
         let snapshot = Filespace.Snapshot(
             linesHash: editor.lines.hashValue,
@@ -174,7 +176,7 @@ extension Workspace {
         cancelInFlightRealtimeSuggestionRequests()
         lastTriggerDate = Environment.now()
 
-        if let editor {
+        if let editor, !editor.uti.isEmpty {
             filespaces[fileURL]?.uti = editor.uti
             filespaces[fileURL]?.tabSize = editor.tabSize
             filespaces[fileURL]?.indentSize = editor.indentSize
@@ -195,7 +197,7 @@ extension Workspace {
               filespace.suggestionIndex < filespace.suggestions.endIndex
         else { return nil }
 
-        if let editor {
+        if let editor, !editor.uti.isEmpty {
             filespaces[fileURL]?.uti = editor.uti
             filespaces[fileURL]?.tabSize = editor.tabSize
             filespaces[fileURL]?.indentSize = editor.indentSize


### PR DESCRIPTION
A workaround for #70 

But it has some drawbacks:
- The change is not in-place, if a user undos a acceptation, the whole file will be selected and the editor will scroll to top.
- Calculation the selected range is too cumbersome so I just restored the old one before the acceptation.