### PR TITLE
Support more languages

### DIFF
--- a/Core/Sources/CopilotService/CopilotRequest.swift
+++ b/Core/Sources/CopilotService/CopilotRequest.swift
@@ -11,7 +11,7 @@ struct CopilotDoc: Codable {
     var path: String
     var uri: String
     var relativePath: String
-    var languageId: LanguageIdentifier
+    var languageId: CopilotLanguage
     var position: Position
     /// Buffer version. Not sure what this is for, not sure how to get it
     var version: Int = 0

--- a/Core/Sources/CopilotService/CopilotService.swift
+++ b/Core/Sources/CopilotService/CopilotService.swift
@@ -156,8 +156,8 @@ public final class CopilotSuggestionService: CopilotBaseService, CopilotSuggesti
         usesTabsForIndentation: Bool,
         ignoreSpaceOnlySuggestions: Bool
     ) async throws -> [CopilotCompletion] {
-        guard let languageId = languageIdentifierFromFileURL(fileURL) else { return [] }
-
+        let languageId = languageIdentifierFromFileURL(fileURL)
+        
         let relativePath = {
             let filePath = fileURL.path
             let rootPath = projectRootURL.path

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -230,7 +230,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         Task {
             try? await service.send(
                 content: """
-                ```\(codeLanguage?.rawValue ?? "")
+                ```\(codeLanguage.rawValue)
                 \(removeContinuousSpaces(from: code))
                 ```
                 """,
@@ -278,7 +278,7 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
             return """
             \(language.isEmpty ? "" : "You must always reply in \(language)")
             You are a senior programmer, you will answer my questions concisely about the code below, or modify it according to my requests. When you receive a modification request, reply with the modified code in a code block.
-            ```\(codeLanguage?.rawValue ?? "")
+            ```\(codeLanguage.rawValue)
             \(removeContinuousSpaces(from: code))
             ```
             """

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -14,8 +14,7 @@ final class Filespace {
     }
 
     let fileURL: URL
-    private(set) lazy var language: String = languageIdentifierFromFileURL(fileURL)?
-        .rawValue ?? "plaintext"
+    private(set) lazy var language: String = languageIdentifierFromFileURL(fileURL).rawValue
     var suggestions: [CopilotCompletion] = [] {
         didSet { lastSuggestionUpdateTime = Environment.now() }
     }


### PR DESCRIPTION
In previous releases, GitHub Copilot won't generate suggestions for languages not listed in enum `LanguageIdentifier`, we are removing this limitation.

If a language identifier is not detected, we will just use it's path extension as the language