### PR TITLE
Hide common preceding spaces for suggestion

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Splash", from: "0.1.0"),
         .package(url: "https://github.com/nmdias/FeedKit", from: "9.1.2"),
         .package(url: "https://github.com/intitni/swift-markdown-ui", branch: "main"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"), 
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
     ],
     targets: [
         .target(name: "CGEventObserver"),
@@ -123,9 +123,11 @@ let package = Package(
                 "Environment",
                 "Highlightr",
                 "Splash",
+                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "MarkdownUI", package: "swift-markdown-ui"),
             ]
         ),
+        .testTarget(name: "SuggestionWidgetTests", dependencies: ["SuggestionWidget"]),
         .target(
             name: "UpdateChecker",
             dependencies: [

--- a/Core/Sources/Preferences/Keys.swift
+++ b/Core/Sources/Preferences/Keys.swift
@@ -116,6 +116,15 @@ public struct UserDefaultPreferenceKeys {
 
     public var useGlobalChat: UseGlobalChat { .init() }
 
+    public struct HideCommonPrecedingSpacesInSuggestion: UserDefaultPreferenceKey {
+        public let defaultValue = false
+        public let key = "HideCommonPrecedingSpacesInSuggestion"
+    }
+
+    public var hideCommonPrecedingSpacesInSuggestion: HideCommonPrecedingSpacesInSuggestion {
+        .init()
+    }
+
     public var disableLazyVStack: FeatureFlags.DisableLazyVStack { .init() }
 }
 

--- a/Core/Sources/Service/GUI/WidgetDataSource.swift
+++ b/Core/Sources/Service/GUI/WidgetDataSource.swift
@@ -18,6 +18,7 @@ final class WidgetDataSource {
         if useGlobalChat {
             chat = globalChat ?? ChatService(chatGPTService: ChatGPTService())
             globalChat = chat
+            
         } else {
             chat = chats[url] ?? ChatService(chatGPTService: ChatGPTService())
             chats[url] = chat

--- a/Core/Sources/Service/GUI/WidgetDataSource.swift
+++ b/Core/Sources/Service/GUI/WidgetDataSource.swift
@@ -18,7 +18,6 @@ final class WidgetDataSource {
         if useGlobalChat {
             chat = globalChat ?? ChatService(chatGPTService: ChatGPTService())
             globalChat = chat
-            
         } else {
             chat = chats[url] ?? ChatService(chatGPTService: ChatGPTService())
             chats[url] = chat

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
@@ -5,7 +5,7 @@ struct CodeBlock: View {
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
-        VStack {
+        VStack(spacing: 4) {
             let code = suggestion.highlightedCode(colorScheme: colorScheme)
             ForEach(0..<code.endIndex, id: \.self) { index in
                 HStack(alignment: .firstTextBaseline) {
@@ -18,6 +18,15 @@ struct CodeBlock: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .multilineTextAlignment(.leading)
                         .lineSpacing(4)
+                        .overlay(alignment: .topLeading) {
+                            if index == 0 {
+                                Text("\(suggestion.commonPrecedingSpaceCount + 1)")
+                                    .padding(.top, -12)
+                                    .font(.footnote)
+                                    .foregroundStyle(colorScheme == .dark ? .white : .black)
+                                    .opacity(0.3)
+                            }
+                        }
                 }
             }
         }
@@ -171,7 +180,7 @@ struct CodeBlockSuggestionPanel_Dark_Objc_Preview: PreviewProvider {
 
 struct CodeBlockSuggestionPanel_Bright_Objc_Preview: PreviewProvider {
     static var previews: some View {
-        CodeBlockSuggestionPanel(suggestion:SuggestionProvider(
+        CodeBlockSuggestionPanel(suggestion: SuggestionProvider(
             code: """
             - (void)addSubview:(UIView *)view {
                 [self addSubview:view];

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
@@ -19,7 +19,7 @@ struct CodeBlock: View {
                         .multilineTextAlignment(.leading)
                         .lineSpacing(4)
                         .overlay(alignment: .topLeading) {
-                            if index == 0 {
+                            if index == 0, suggestion.commonPrecedingSpaceCount > 0 {
                                 Text("\(suggestion.commonPrecedingSpaceCount + 1)")
                                     .padding(.top, -12)
                                     .font(.footnote)

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlockSuggestionPanel.swift
@@ -8,7 +8,7 @@ struct CodeBlock: View {
         VStack(spacing: 4) {
             let code = suggestion.highlightedCode(colorScheme: colorScheme)
             ForEach(0..<code.endIndex, id: \.self) { index in
-                HStack(alignment: .firstTextBaseline) {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(index + suggestion.startLineIndex + 1)")
                         .multilineTextAlignment(.trailing)
                         .foregroundColor(.secondary)
@@ -32,7 +32,8 @@ struct CodeBlock: View {
         }
         .foregroundColor(.white)
         .font(.system(size: 12, design: .monospaced))
-        .padding()
+        .padding(.leading, 4)
+        .padding([.trailing, .top, .bottom])
     }
 }
 

--- a/Core/Sources/SuggestionWidget/SuggestionProvider.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionProvider.swift
@@ -27,7 +27,9 @@ public final class SuggestionProvider: ObservableObject {
             droppingLeadingSpaces: true
         )
         highlightedCode = new
-        commonPrecedingSpaceCount = spaceCount
+        Task { @MainActor in
+            commonPrecedingSpaceCount = spaceCount
+        }
         return new
     }
     

--- a/Core/Sources/SuggestionWidget/SuggestionProvider.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionProvider.swift
@@ -11,22 +11,26 @@ public final class SuggestionProvider: ObservableObject {
     @Published public var startLineIndex: Int = 0
     @Published public var suggestionCount: Int = 0
     @Published public var currentSuggestionIndex: Int = 0
+    @Published public var commonPrecedingSpaceCount = 0
     
     private var colorScheme: ColorScheme = .light
     private var highlightedCode: [NSAttributedString]? = nil
+    
     func highlightedCode(colorScheme: ColorScheme) -> [NSAttributedString] {
         if colorScheme != self.colorScheme { highlightedCode = nil }
         self.colorScheme = colorScheme
         if let highlightedCode { return highlightedCode }
-        let new = highlighted(
+        let (new, spaceCount) = highlighted(
             code: code,
             language: language,
-            brightMode: colorScheme != .dark
+            brightMode: colorScheme != .dark,
+            droppingLeadingSpaces: true
         )
         highlightedCode = new
+        commonPrecedingSpaceCount = spaceCount
         return new
     }
-
+    
     public var onSelectPreviousSuggestionTapped: () -> Void
     public var onSelectNextSuggestionTapped: () -> Void
     public var onRejectSuggestionTapped: () -> Void

--- a/Core/Sources/SuggestionWidget/SuggestionProvider.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionProvider.swift
@@ -5,17 +5,19 @@ public final class SuggestionProvider: ObservableObject {
     @Published public var code: String = "" {
         didSet { highlightedCode = nil }
     }
+
     @Published public var language: String = "" {
         didSet { highlightedCode = nil }
     }
+
     @Published public var startLineIndex: Int = 0
     @Published public var suggestionCount: Int = 0
     @Published public var currentSuggestionIndex: Int = 0
     @Published public var commonPrecedingSpaceCount = 0
-    
+
     private var colorScheme: ColorScheme = .light
-    private var highlightedCode: [NSAttributedString]? = nil
-    
+    private var highlightedCode: [NSAttributedString]?
+
     func highlightedCode(colorScheme: ColorScheme) -> [NSAttributedString] {
         if colorScheme != self.colorScheme { highlightedCode = nil }
         self.colorScheme = colorScheme
@@ -24,7 +26,8 @@ public final class SuggestionProvider: ObservableObject {
             code: code,
             language: language,
             brightMode: colorScheme != .dark,
-            droppingLeadingSpaces: true
+            droppingLeadingSpaces: UserDefaults.shared
+                .value(for: \.hideCommonPrecedingSpacesInSuggestion)
         )
         highlightedCode = new
         Task { @MainActor in
@@ -32,7 +35,7 @@ public final class SuggestionProvider: ObservableObject {
         }
         return new
     }
-    
+
     public var onSelectPreviousSuggestionTapped: () -> Void
     public var onSelectNextSuggestionTapped: () -> Void
     public var onRejectSuggestionTapped: () -> Void

--- a/Core/Sources/SuggestionWidget/SyntaxHighlighting.swift
+++ b/Core/Sources/SuggestionWidget/SyntaxHighlighting.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Foundation
 import Highlightr
-import Splash
 import SwiftUI
 import XPCShared
 
@@ -11,73 +10,31 @@ func highlightedCodeBlock(
     brightMode: Bool,
     fontSize: Double
 ) -> NSAttributedString {
-    switch language {
-    case "swift":
-        let plainTextColor = brightMode
-            ? .black
-            : #colorLiteral(red: 0.6509803922, green: 0.6980392157, blue: 0.7529411765, alpha: 1)
-        let highlighter =
-            SyntaxHighlighter(
-                format: AttributedStringOutputFormat(theme: .init(
-                    font: .init(size: 14),
-                    plainTextColor: plainTextColor,
-                    tokenColors: brightMode
-                        ? [
-                            .keyword: #colorLiteral(red: 0.6078431373, green: 0.137254902, blue: 0.5764705882, alpha: 1),
-                            .string: #colorLiteral(red: 0.1371159852, green: 0.3430536985, blue: 0.362406373, alpha: 1),
-                            .type: #colorLiteral(red: 0.2456904352, green: 0.5002114773, blue: 0.5297455192, alpha: 1),
-                            .call: #colorLiteral(red: 0.1960784314, green: 0.4274509804, blue: 0.4549019608, alpha: 1),
-                            .number: #colorLiteral(red: 0.4385872483, green: 0.4995297194, blue: 0.5483990908, alpha: 1),
-                            .comment: #colorLiteral(red: 0.3647058824, green: 0.4235294118, blue: 0.4745098039, alpha: 1),
-                            .property: #colorLiteral(red: 0.1960784314, green: 0.4274509804, blue: 0.4549019608, alpha: 1),
-                            .dotAccess: #colorLiteral(red: 0.1960784314, green: 0.4274509804, blue: 0.4549019608, alpha: 1),
-                            .preprocessing: #colorLiteral(red: 0.3921568627, green: 0.2196078431, blue: 0.1254901961, alpha: 1),
-                        ] : [
-                            .keyword: #colorLiteral(red: 0.8258609176, green: 0.5708742738, blue: 0.8922662139, alpha: 1),
-                            .string: #colorLiteral(red: 0.6253595352, green: 0.7963448763, blue: 0.5427476764, alpha: 1),
-                            .type: #colorLiteral(red: 0.9221783876, green: 0.7978314757, blue: 0.5575165749, alpha: 1),
-                            .call: #colorLiteral(red: 0.4466812611, green: 0.742190659, blue: 0.9515134692, alpha: 1),
-                            .number: #colorLiteral(red: 0.8620631099, green: 0.6468816996, blue: 0.4395158887, alpha: 1),
-                            .comment: #colorLiteral(red: 0.4233166873, green: 0.4612616301, blue: 0.5093258619, alpha: 1),
-                            .property: #colorLiteral(red: 0.906378448, green: 0.5044228435, blue: 0.5263597369, alpha: 1),
-                            .dotAccess: #colorLiteral(red: 0.906378448, green: 0.5044228435, blue: 0.5263597369, alpha: 1),
-                            .preprocessing: #colorLiteral(red: 0.3776347041, green: 0.8792117238, blue: 0.4709561467, alpha: 1),
-                        ]
-                ))
-            )
-        let formatted = NSMutableAttributedString(attributedString: highlighter.highlight(code))
-        formatted.addAttributes(
-            [.font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)],
-            range: NSRange(location: 0, length: formatted.length)
-        )
-        return formatted
-    default:
-        var language = language
-        if language == "objective-c" {
-            language = "objectivec"
-        }
-        func unhighlightedCode() -> NSAttributedString {
-            return NSAttributedString(
-                string: code,
-                attributes: [
-                    .foregroundColor: brightMode ? NSColor.black : NSColor.white,
-                    .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
-                ]
-            )
-        }
-        guard let highlighter = Highlightr() else {
-            return unhighlightedCode()
-        }
-        highlighter.setTheme(to: brightMode ? "xcode" : "atom-one-dark")
-        highlighter.theme.setCodeFont(.monospacedSystemFont(ofSize: fontSize, weight: .regular))
-        guard let formatted = highlighter.highlight(code, as: language) else {
-            return unhighlightedCode()
-        }
-        if formatted.string == "undefined" {
-            return unhighlightedCode()
-        }
-        return formatted
+    var language = language
+    if language == "objective-c" {
+        language = "objectivec"
     }
+    func unhighlightedCode() -> NSAttributedString {
+        return NSAttributedString(
+            string: code,
+            attributes: [
+                .foregroundColor: brightMode ? NSColor.black : NSColor.white,
+                .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            ]
+        )
+    }
+    guard let highlighter = Highlightr() else {
+        return unhighlightedCode()
+    }
+    highlighter.setTheme(to: brightMode ? "xcode" : "atom-one-dark")
+    highlighter.theme.setCodeFont(.monospacedSystemFont(ofSize: fontSize, weight: .regular))
+    guard let formatted = highlighter.highlight(code, as: language) else {
+        return unhighlightedCode()
+    }
+    if formatted.string == "undefined" {
+        return unhighlightedCode()
+    }
+    return formatted
 }
 
 func highlighted(code: String, language: String, brightMode: Bool) -> [NSAttributedString] {

--- a/Core/Sources/SuggestionWidget/SyntaxHighlighting.swift
+++ b/Core/Sources/SuggestionWidget/SyntaxHighlighting.swift
@@ -37,7 +37,12 @@ func highlightedCodeBlock(
     return formatted
 }
 
-func highlighted(code: String, language: String, brightMode: Bool) -> [NSAttributedString] {
+func highlighted(
+    code: String,
+    language: String,
+    brightMode: Bool,
+    droppingLeadingSpaces: Bool
+) -> (code: [NSAttributedString], commonLeadingSpaceCount: Int) {
     let formatted = highlightedCodeBlock(
         code: code,
         language: language,
@@ -47,24 +52,70 @@ func highlighted(code: String, language: String, brightMode: Bool) -> [NSAttribu
     let middleDotColor = brightMode
         ? NSColor.black.withAlphaComponent(0.1)
         : NSColor.white.withAlphaComponent(0.1)
-    return convertToCodeLines(formatted, middleDotColor: middleDotColor)
+    return convertToCodeLines(
+        formatted,
+        middleDotColor: middleDotColor,
+        droppingLeadingSpaces: droppingLeadingSpaces
+    )
 }
 
-private func convertToCodeLines(
+func convertToCodeLines(
     _ formattedCode: NSAttributedString,
-    middleDotColor: NSColor
-) -> [NSAttributedString] {
+    middleDotColor: NSColor,
+    droppingLeadingSpaces: Bool
+) -> (code: [NSAttributedString], commonLeadingSpaceCount: Int) {
     let input = formattedCode.string
+    func isEmptyLine(_ line: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: #"^\s*\n?$"#) else { return false }
+        if regex.firstMatch(
+            in: line,
+            options: [],
+            range: NSMakeRange(0, line.utf16.count)
+        ) != nil {
+            return true
+        }
+        return false
+    }
+
     let separatedInput = input.components(separatedBy: "\n")
+    let commonLeadingSpaceCount = {
+        if !droppingLeadingSpaces { return 0 }
+        let splitted = separatedInput
+        var result = 0
+        outerLoop: for i in [4, 8, 12, 16, 20] {
+            for line in splitted {
+                if isEmptyLine(line) { continue }
+                if i >= line.count { break outerLoop }
+                let targetIndex = line.index(line.startIndex, offsetBy: i - 1)
+                if line[targetIndex] != " " { break outerLoop }
+            }
+            result = i
+        }
+        return result
+    }()
     var output = [NSAttributedString]()
     var start = 0
     for sub in separatedInput {
         let range = NSMakeRange(start, sub.utf16.count)
         let attributedString = formattedCode.attributedSubstring(from: range)
         let mutable = NSMutableAttributedString(attributedString: attributedString)
+
+        // remove leading spaces
+        if commonLeadingSpaceCount > 0 {
+            let leadingSpaces = String(repeating: " ", count: commonLeadingSpaceCount)
+            if isEmptyLine(mutable.string) {
+                mutable.mutableString.setString("")
+            } else if mutable.string.hasPrefix(leadingSpaces) {
+                mutable.replaceCharacters(
+                    in: NSRange(location: 0, length: commonLeadingSpaceCount),
+                    with: ""
+                )
+            }
+        }
+
         // use regex to replace all spaces to a middle dot
         do {
-            let regex = try NSRegularExpression(pattern: "[ ]*", options: [])
+            let regex = try NSRegularExpression(pattern: #"\s*"#, options: [])
             let result = regex.matches(
                 in: mutable.string,
                 range: NSRange(location: 0, length: mutable.mutableString.length)
@@ -83,5 +134,5 @@ private func convertToCodeLines(
         output.append(mutable)
         start += range.length + 1
     }
-    return output
+    return (output, commonLeadingSpaceCount)
 }

--- a/Core/Sources/SuggestionWidget/WidgetView.swift
+++ b/Core/Sources/SuggestionWidget/WidgetView.swift
@@ -93,6 +93,7 @@ struct WidgetContextMenu: View {
     @AppStorage(\.useGlobalChat) var useGlobalChat
     @AppStorage(\.realtimeSuggestionToggle) var realtimeSuggestionToggle
     @AppStorage(\.acceptSuggestionWithAccessibilityAPI) var acceptSuggestionWithAccessibilityAPI
+    @AppStorage(\.hideCommonPrecedingSpacesInSuggestion) var hideCommonPrecedingSpacesInSuggestion
 
     var body: some View {
         Group {
@@ -119,6 +120,15 @@ struct WidgetContextMenu: View {
             }, label: {
                 Text("Accept Suggestion with Accessibility API")
                 if acceptSuggestionWithAccessibilityAPI {
+                    Image(systemName: "checkmark")
+                }
+            })
+            
+            Button(action: {
+                hideCommonPrecedingSpacesInSuggestion.toggle()
+            }, label: {
+                Text("Hide Common Preceding Spaces in Suggestion")
+                if hideCommonPrecedingSpacesInSuggestion {
                     Image(systemName: "checkmark")
                 }
             })

--- a/Core/Tests/SuggestionWidgetTests/ConvertToCodeLinesTests.swift
+++ b/Core/Tests/SuggestionWidgetTests/ConvertToCodeLinesTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+@testable import SuggestionWidget
+
+final class ConvertToCodeLinesTests: XCTestCase {
+    func test_do_not_remove_common_leading_spaces() async throws {
+        let code = """
+            struct Cat {
+            }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: false
+        )
+
+        XCTAssertEqual(spaceCount, 0)
+        print(code.replacingOccurrences(of: " ", with: "·"))
+        XCTAssertEqual(result.map(\.string), [
+            "····struct·Cat·{",
+            "····}",
+        ])
+    }
+    
+    func test_wont_remove_common_leading_spaces_2_spaces() async throws {
+        let code = """
+          struct Cat {
+            }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 0)
+        XCTAssertEqual(result.map(\.string), [
+            "··struct·Cat·{",
+            "····}",
+        ])
+    }
+    
+    func test_remove_common_leading_spaces_4_spaces() async throws {
+        let code = """
+            struct Cat {
+            }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 4)
+        XCTAssertEqual(result.map(\.string), [
+            "struct·Cat·{",
+            "}",
+        ])
+    }
+    
+    func test_remove_common_leading_spaces_8_spaces() async throws {
+        let code = """
+                struct Cat {
+                }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 8)
+        XCTAssertEqual(result.map(\.string), [
+            "struct·Cat·{",
+            "}",
+        ])
+    }
+
+    func test_remove_common_leading_spaces_one_line_is_empty() async throws {
+        let code = """
+            struct Cat {
+
+            }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 4)
+        XCTAssertEqual(result.map(\.string), [
+            "struct·Cat·{",
+            "",
+            "}",
+        ])
+    }
+    
+    func test_remove_common_leading_spaces_one_line_has_no_leading_spaces() async throws {
+        let code = """
+            struct Cat {
+        //
+            }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 0)
+        XCTAssertEqual(result.map(\.string), [
+            "····struct·Cat·{",
+            "//",
+            "····}",
+        ])
+    }
+    
+    func test_remove_common_leading_spaces_one_line_has_fewer_leading_spaces() async throws {
+        let code = """
+                struct Cat {
+            //
+                }
+        """
+        let (result, spaceCount) = highlighted(
+            code: code,
+            language: "md",
+            brightMode: true,
+            droppingLeadingSpaces: true
+        )
+
+        XCTAssertEqual(spaceCount, 4)
+        XCTAssertEqual(result.map(\.string), [
+            "····struct·Cat·{",
+            "//",
+            "····}",
+        ])
+    }
+}

--- a/TestPlan.xctestplan
+++ b/TestPlan.xctestplan
@@ -56,6 +56,13 @@
         "identifier" : "OpenAIServiceTests",
         "name" : "OpenAIServiceTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Core",
+        "identifier" : "SuggestionWidgetTests",
+        "name" : "SuggestionWidgetTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
To improve the readability for suggestions on highly nested SwiftUI code.

We will stop using Splash to highlight Swift code, too. Because Splash has a weird bug that it will add an extra space to the first line of the code. And it hasn't got any release for a long time.