### PR TITLE
Update suggestion caching mechanism

### DIFF
--- a/Core/Sources/Service/RealtimeSuggestionController.swift
+++ b/Core/Sources/Service/RealtimeSuggestionController.swift
@@ -134,27 +134,6 @@ public class RealtimeSuggestionController {
                 }
             }
         }
-
-        Task { // Get cache ready for real-time suggestions.
-            guard
-                let fileURL = try? await Environment.fetchCurrentFileURL(),
-                let (_, filespace) = try? await Workspace
-                .fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
-            else { return }
-
-            if filespace.uti == nil {
-                Logger.service.info("Generate cache for file.")
-                // avoid the command get called twice
-                filespace.uti = ""
-                do {
-                    try await Environment.triggerAction("Real-time Suggestions")
-                } catch {
-                    if filespace.uti?.isEmpty ?? true {
-                        filespace.uti = nil
-                    }
-                }
-            }
-        }
     }
 
     func handleHIDEvent(event: CGEvent) async {

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ fi
 - The first run of the extension will be slow. Be patient.
 - The extension uses some dirty tricks to get the file and project/workspace paths. It may fail, it may be incorrect, especially when you have multiple Xcode windows running, and maybe even worse when they are in different displays. I am not sure about that though.
 - The suggestions are presented as C-style comments in comment mode, they may break your code if you are editing a JSON file or something.
+- When a real-time suggestion request is triggered, there is a chance that it may briefly block the editor. This can occur at most once for each file after each restart of the extension because the extension needs to initiate real-time suggestion by clicking an item from the menu bar. However, once a command has been executed and some information is cached, the extension will be able to trigger real-time suggestion using a different method.
 
 ## License 
 


### PR DESCRIPTION
Looks like the current caching mechanism may disable the source extension sometimes. I have no evidence that this is the cause, but I just can't think of another one.

We have rollback to use menu bar command to fetch real-time suggestion when needed, but added new a rule that it will not use this method when the completion panel is displayed.