### PR TITLE
Continuous prompt to code

### DIFF
--- a/Core/Sources/CopilotModel/ExportedFromLSP.swift
+++ b/Core/Sources/CopilotModel/ExportedFromLSP.swift
@@ -9,4 +9,7 @@ public extension CursorPosition {
 
 public extension CursorRange {
     static var outOfScope: CursorRange { .init(start: .outOfScope, end: .outOfScope) }
+    static func cursor(_ position: CursorPosition) -> CursorRange {
+        return .init(start: position, end: position)
+    }
 }

--- a/Core/Sources/PromptToCodeService/PromptToCodeService.swift
+++ b/Core/Sources/PromptToCodeService/PromptToCodeService.swift
@@ -128,6 +128,9 @@ final class OpenAIPromptToCodeAPI: PromptToCodeAPI {
         usesTabsForIndentation: Bool,
         requirement: String
     ) async throws -> AsyncThrowingStream<(code: String, description: String), Error> {
+        let userPreferredLanguage = UserDefaults.shared.value(for: \.chatGPTLanguage)
+        let textLanguage = userPreferredLanguage.isEmpty ? "" : "in \(userPreferredLanguage)"
+        
         let prompt = {
             let indentRule = usesTabsForIndentation ? "\(indentSize) tabs" : "\(indentSize) spaces"
             if code.isEmpty {
@@ -138,7 +141,7 @@ final class OpenAIPromptToCodeAPI: PromptToCodeAPI {
                     indentRule
                 ).
 
-                Please reply to me start with the code block, followed by a short description in 1-3 sentences about what you did.
+                Please reply to me start with the code block, followed by a short description in 1-3 sentences about what you did \(textLanguage).
                 """
             } else {
                 return """
@@ -148,7 +151,7 @@ final class OpenAIPromptToCodeAPI: PromptToCodeAPI {
                     indentRule
                 ).
 
-                Please reply to me start with the code block followed by a short description about what you did in 1-3 sentences.
+                Please reply to me start with the code block followed by a short description about what you did in 1-3 sentences \(textLanguage).
 
                 ```
                 \(code)

--- a/Core/Sources/PromptToCodeService/PromptToCodeService.swift
+++ b/Core/Sources/PromptToCodeService/PromptToCodeService.swift
@@ -21,6 +21,7 @@ public final class PromptToCodeService: ObservableObject {
     public var language: CopilotLanguage
     public var indentSize: Int
     public var usesTabsForIndentation: Bool
+    public var isContinuous = false
 
     public init(
         code: String,

--- a/Core/Sources/PromptToCodeService/PromptToCodeService.swift
+++ b/Core/Sources/PromptToCodeService/PromptToCodeService.swift
@@ -41,7 +41,7 @@ public final class PromptToCodeService: ObservableObject {
         let api = promptToCodeAPI
         runningAPI = api
         isResponding = true
-        let toBemodified = code
+        let toBeModified = code
         oldDescription = description
         oldCode = code
         code = ""
@@ -49,7 +49,7 @@ public final class PromptToCodeService: ObservableObject {
         defer { isResponding = false }
         do {
             let stream = try await api.modifyCode(
-                code: toBemodified,
+                code: toBeModified,
                 language: language,
                 indentSize: indentSize,
                 usesTabsForIndentation: usesTabsForIndentation,

--- a/Core/Sources/PromptToCodeService/PromptToCodeService.swift
+++ b/Core/Sources/PromptToCodeService/PromptToCodeService.swift
@@ -15,13 +15,13 @@ public final class PromptToCodeService: ObservableObject {
     @Published public var code: String
     @Published public var isResponding: Bool = false
     @Published public var description: String = ""
+    @Published public var isContinuous = false
     public var oldDescription: String?
     public var canRevert: Bool { oldCode != nil }
     public var selectionRange: CursorRange
     public var language: CopilotLanguage
     public var indentSize: Int
     public var usesTabsForIndentation: Bool
-    public var isContinuous = false
 
     public init(
         code: String,

--- a/Core/Sources/Service/GUI/PromptToCodeProvider+Service.swift
+++ b/Core/Sources/Service/GUI/PromptToCodeProvider+Service.swift
@@ -17,6 +17,7 @@ extension PromptToCodeProvider {
         service.$code.sink(receiveValue: set(\.code)).store(in: &cancellables)
         service.$isResponding.sink(receiveValue: set(\.isResponding)).store(in: &cancellables)
         service.$description.sink(receiveValue: set(\.description)).store(in: &cancellables)
+        service.$isContinuous.sink(receiveValue: set(\.isContinuous)).store(in: &cancellables)
         service.$oldCode.map { $0 != nil }
             .sink(receiveValue: set(\.canRevert)).store(in: &cancellables)
 
@@ -51,6 +52,10 @@ extension PromptToCodeProvider {
                 let handler = PseudoCommandHandler()
                 await handler.acceptSuggestion()
             }
+        }
+        
+        onContinuousToggleClick = {
+            service.isContinuous.toggle()
         }
     }
 

--- a/Core/Sources/Service/GUI/PromptToCodeProvider+Service.swift
+++ b/Core/Sources/Service/GUI/PromptToCodeProvider+Service.swift
@@ -35,6 +35,8 @@ extension PromptToCodeProvider {
             Task { [weak self] in
                 do {
                     try await service.modifyCode(prompt: requirement)
+                } catch is CancellationError {
+                    return
                 } catch {
                     Task { @MainActor [weak self] in
                         self?.errorMessage = error.localizedDescription

--- a/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
@@ -103,7 +103,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
 
         return .init(
             content: String(lines.joined(separator: "")),
-            newCursor: cursorPosition,
+            newSelection: .cursor(cursorPosition),
             modifications: extraInfo.modifications
         )
     }

--- a/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
@@ -108,7 +108,8 @@ struct PseudoCommandHandler {
                         .presentErrorMessage("Fail to set editor content.")
                 }
 
-                if let cursor = result.newCursor {
+                #warning("MUSTDO: handle range")
+                if let cursor = result.newSelection?.start {
                     var range = convertCursorPositionToRange(cursor, in: result.content)
                     if let value = AXValueCreate(.cfRange, &range) {
                         AXUIElementSetAttributeValue(

--- a/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
@@ -70,7 +70,7 @@ struct PseudoCommandHandler {
 
     func acceptSuggestion() async {
         if UserDefaults.shared.value(for: \.acceptSuggestionWithAccessibilityAPI) {
-            guard let xcode = ActiveApplicationMonitor.activeXcode else { return }
+            guard let xcode = ActiveApplicationMonitor.activeXcode ?? ActiveApplicationMonitor.latestXcode else { return }
             let application = AXUIElementCreateApplication(xcode.processIdentifier)
             guard let focusElement = application.focusedElement,
                   focusElement.description == "Source Editor"
@@ -108,9 +108,8 @@ struct PseudoCommandHandler {
                         .presentErrorMessage("Fail to set editor content.")
                 }
 
-                #warning("MUSTDO: handle range")
-                if let cursor = result.newSelection?.start {
-                    var range = convertCursorPositionToRange(cursor, in: result.content)
+                if let selection = result.newSelection {
+                    var range = convertCursorRangeToRange(selection, in: result.content)
                     if let value = AXValueCreate(.cfRange, &range) {
                         AXUIElementSetAttributeValue(
                             focusElement,
@@ -219,21 +218,28 @@ private extension PseudoCommandHandler {
         )
     }
 
-    // a function to convert CursorPosition(line:character:) into a Range(location:length) in given
-    // content
-    func convertCursorPositionToRange(
-        _ cursorPosition: CursorPosition,
+    func convertCursorRangeToRange(
+        _ cursorRange: CursorRange,
         in content: String
     ) -> CFRange {
         let lines = content.breakLines()
-        var count = 0
+        var countS = 0
+        var countE = 0
+        var range = CFRange(location: 0, length: 0)
         for (i, line) in lines.enumerated() {
-            if i == cursorPosition.line {
-                return CFRange(location: count + cursorPosition.character, length: 0)
+            if i == cursorRange.start.line {
+                countS = countS + cursorRange.start.character
+                range.location = countS
             }
-            count += line.count
+            if i == cursorRange.end.line {
+                countE = countE + cursorRange.end.character
+                range.length = max(countE - range.location, 0)
+                break
+            }
+            countS += line.count
+            countE += line.count
         }
-        return CFRange(location: count, length: 0)
+        return range
     }
 }
 

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -353,8 +353,10 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
             guard var selection = editor.selections.last,
                   selection.start != selection.end
             else { return ("", .cursor(editor.cursorPosition)) }
-            // always start from char 0 so that it can keep the indentation.
-            selection.start = .init(line: selection.start.line, character: 0)
+            if selection.start.line != selection.end.line {
+                // when there are multiple lines start from char 0 so that it can keep the indentation.
+                selection.start = .init(line: selection.start.line, character: 0)
+            }
             return (
                 editor.selectedCode(in: selection),
                 .init(

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -140,70 +140,64 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         let fileURL = try await Environment.fetchCurrentFileURL()
         let (workspace, _) = try await Workspace.fetchOrCreateWorkspaceIfNeeded(fileURL: fileURL)
 
-        let result: (
-            suggestion: CopilotCompletion,
-            cleanup: () -> Void,
-            startPosition: CursorPosition?
-        )? = {
-            if let service = WidgetDataSource.shared.promptToCodes[fileURL]?.promptToCodeService {
-                return (
-                    CopilotCompletion(
-                        text: service.code,
-                        position: service.selectionRange.start,
-                        uuid: UUID().uuidString,
-                        range: service.selectionRange,
-                        displayText: service.code
-                    ),
-                    {
-                        WidgetDataSource.shared.removePromptToCode(for: fileURL)
-                        presenter.closePromptToCode(fileURL: fileURL)
-                    },
-                    service.selectionRange.start
-                )
-            }
-
-            if let acceptedSuggestion = workspace.acceptSuggestion(
-                forFileAt: fileURL,
-                editor: editor
-            ) {
-                return (
-                    acceptedSuggestion,
-                    {
-                        presenter.discardSuggestion(fileURL: fileURL)
-                    },
-                    nil
-                )
-            }
-
-            return nil
-        }()
-
-        guard let result else { return nil }
-
         let injector = SuggestionInjector()
         var lines = editor.lines
         var cursorPosition = editor.cursorPosition
         var extraInfo = SuggestionInjector.ExtraInfo()
 
-        injector.acceptSuggestion(
-            intoContentWithoutSuggestion: &lines,
-            cursorPosition: &cursorPosition,
-            completion: result.suggestion,
-            extraInfo: &extraInfo
-        )
+        if let service = WidgetDataSource.shared.promptToCodes[fileURL]?.promptToCodeService {
+            let suggestion = CopilotCompletion(
+                text: service.code,
+                position: service.selectionRange.start,
+                uuid: UUID().uuidString,
+                range: service.selectionRange,
+                displayText: service.code
+            )
 
-        result.cleanup()
+            injector.acceptSuggestion(
+                intoContentWithoutSuggestion: &lines,
+                cursorPosition: &cursorPosition,
+                completion: suggestion,
+                extraInfo: &extraInfo
+            )
 
-        return .init(
-            content: String(lines.joined(separator: "")),
-            newSelection: {
-                if let startPosition = result.startPosition {
-                    return .init(start: startPosition, end: cursorPosition)
-                }
-                return .cursor(cursorPosition)
-            }(),
-            modifications: extraInfo.modifications
-        )
+            if service.isContinuous {
+                service.selectionRange = .init(
+                    start: service.selectionRange.start,
+                    end: cursorPosition
+                )
+                presenter.presentPromptToCode(fileURL: fileURL)
+            } else {
+                WidgetDataSource.shared.removePromptToCode(for: fileURL)
+                presenter.closePromptToCode(fileURL: fileURL)
+            }
+
+            return .init(
+                content: String(lines.joined(separator: "")),
+                newSelection: .init(start: service.selectionRange.start, end: cursorPosition),
+                modifications: extraInfo.modifications
+            )
+        } else if let acceptedSuggestion = workspace.acceptSuggestion(
+            forFileAt: fileURL,
+            editor: editor
+        ) {
+            injector.acceptSuggestion(
+                intoContentWithoutSuggestion: &lines,
+                cursorPosition: &cursorPosition,
+                completion: acceptedSuggestion,
+                extraInfo: &extraInfo
+            )
+
+            presenter.discardSuggestion(fileURL: fileURL)
+
+            return .init(
+                content: String(lines.joined(separator: "")),
+                newSelection: .cursor(cursorPosition),
+                modifications: extraInfo.modifications
+            )
+        }
+
+        return nil
     }
 
     func presentRealtimeSuggestions(editor: EditorContent) async throws -> UpdatedContent? {
@@ -348,13 +342,14 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         defer { presenter.markAsProcessing(false) }
         let fileURL = try await Environment.fetchCurrentFileURL()
         let codeLanguage = languageIdentifierFromFileURL(fileURL)
-        
+
         let (code, selection) = {
             guard var selection = editor.selections.last,
                   selection.start != selection.end
             else { return ("", .cursor(editor.cursorPosition)) }
             if selection.start.line != selection.end.line {
-                // when there are multiple lines start from char 0 so that it can keep the indentation.
+                // when there are multiple lines start from char 0 so that it can keep the
+                // indentation.
                 selection.start = .init(line: selection.start.line, character: 0)
             }
             return (

--- a/Core/Sources/Service/SuggestionPresenter/PresentInCommentSuggestionPresenter.swift
+++ b/Core/Sources/Service/SuggestionPresenter/PresentInCommentSuggestionPresenter.swift
@@ -25,7 +25,7 @@ struct PresentInCommentSuggestionPresenter {
         guard let completion = await filespace.presentingSuggestion else {
             return .init(
                 content: originalContent,
-                newCursor: cursorPosition,
+                newSelection: .cursor(cursorPosition),
                 modifications: extraInfo.modifications
             )
         }
@@ -40,7 +40,7 @@ struct PresentInCommentSuggestionPresenter {
 
         return .init(
             content: String(lines.joined(separator: "")),
-            newCursor: cursorPosition,
+            newSelection: .cursor(cursorPosition),
             modifications: extraInfo.modifications
         )
     }
@@ -65,7 +65,7 @@ struct PresentInCommentSuggestionPresenter {
 
         return .init(
             content: String(lines.joined(separator: "")),
-            newCursor: cursorPosition,
+            newSelection: .cursor(cursorPosition),
             modifications: extraInfo.modifications
         )
     }

--- a/Core/Sources/SuggestionWidget/PromptToCodeProvider.swift
+++ b/Core/Sources/SuggestionWidget/PromptToCodeProvider.swift
@@ -13,12 +13,14 @@ public final class PromptToCodeProvider: ObservableObject {
     @Published public var requirement: String
     @Published public var errorMessage: String
     @Published public var canRevert: Bool
+    @Published public var isContinuous: Bool
 
     public var onRevertTapped: () -> Void
     public var onStopRespondingTap: () -> Void
     public var onCancelTapped: () -> Void
     public var onAcceptSuggestionTapped: () -> Void
     public var onRequirementSent: (String) -> Void
+    public var onContinuousToggleClick: () -> Void
 
     public init(
         code: String = "",
@@ -30,11 +32,13 @@ public final class PromptToCodeProvider: ObservableObject {
         requirement: String = "",
         errorMessage: String = "",
         canRevert: Bool = false,
+        isContinuous: Bool = false,
         onRevertTapped: @escaping () -> Void = {},
         onStopRespondingTap: @escaping () -> Void = {},
         onCancelTapped: @escaping () -> Void = {},
         onAcceptSuggestionTapped: @escaping () -> Void = {},
-        onRequirementSent: @escaping (String) -> Void = { _ in }
+        onRequirementSent: @escaping (String) -> Void = { _ in },
+        onContinuousToggleClick: @escaping () -> Void = {}
     ) {
         self.code = code
         self.language = language
@@ -45,11 +49,13 @@ public final class PromptToCodeProvider: ObservableObject {
         self.requirement = requirement
         self.errorMessage = errorMessage
         self.canRevert = canRevert
+        self.isContinuous = isContinuous
         self.onRevertTapped = onRevertTapped
         self.onStopRespondingTap = onStopRespondingTap
         self.onCancelTapped = onCancelTapped
         self.onAcceptSuggestionTapped = onAcceptSuggestionTapped
         self.onRequirementSent = onRequirementSent
+        self.onContinuousToggleClick = onContinuousToggleClick
     }
 
     func revert() {
@@ -70,4 +76,6 @@ public final class PromptToCodeProvider: ObservableObject {
     }
 
     func acceptSuggestion() { onAcceptSuggestionTapped() }
+    
+    func toggleContinuous() { onContinuousToggleClick() }
 }

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlock.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/CodeBlock.swift
@@ -8,6 +8,8 @@ struct CodeBlock: View {
     let commonPrecedingSpaceCount: Int
     let highlightedCode: [NSAttributedString]
     let firstLinePrecedingSpaceCount: Int
+    
+    @AppStorage(\.disableLazyVStack) var disableLazyVStack
 
     init(
         code: String,
@@ -32,9 +34,22 @@ struct CodeBlock: View {
         commonPrecedingSpaceCount = result.commonLeadingSpaceCount
         highlightedCode = result.code
     }
+    
+    @ViewBuilder
+    func vstack(@ViewBuilder content: () -> some View) -> some View {
+        if disableLazyVStack {
+            VStack(spacing: 4) {
+                content()
+            }
+        } else {
+            LazyVStack(spacing: 4) {
+                content()
+            }
+        }
+    }
 
     var body: some View {
-        VStack(spacing: 4) {
+        vstack {
             ForEach(0..<highlightedCode.endIndex, id: \.self) { index in
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text("\(index + startLineIndex + 1)")

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
@@ -88,8 +88,10 @@ struct PromptToCodePanel: View {
                                 Button(action: {
                                     provider.acceptSuggestion()
                                 }) {
-                                    Text("Accept")
-                                }.buttonStyle(CommandButtonStyle(color: .indigo))
+                                    Text("Accept(⌘ + ⏎)")
+                                }
+                                .buttonStyle(CommandButtonStyle(color: .indigo))
+                                .keyboardShortcut(KeyEquivalent.return, modifiers: [.command])
                             }
                         }
                         .padding(8)

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
@@ -75,9 +75,15 @@ struct PromptToCodePanel: View {
                         .buttonStyle(.plain)
                     } else {
                         HStack {
-                            Toggle("Continuous Mode", isOn: $provider.isContinuous)
-                                .toggleStyle(.checkbox)
-                            
+                            Toggle(
+                                "Continuous Mode",
+                                isOn: .init(
+                                    get: { provider.isContinuous },
+                                    set: { _ in provider.toggleContinuous() }
+                                )
+                            )
+                            .toggleStyle(.checkbox)
+
                             Button(action: {
                                 provider.cancel()
                             }) {

--- a/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionPanelContent/PromptToCodePanel.swift
@@ -75,6 +75,9 @@ struct PromptToCodePanel: View {
                         .buttonStyle(.plain)
                     } else {
                         HStack {
+                            Toggle("Continuous Mode", isOn: $provider.isContinuous)
+                                .toggleStyle(.checkbox)
+                            
                             Button(action: {
                                 provider.cancel()
                             }) {

--- a/Core/Sources/XPCShared/Models.swift
+++ b/Core/Sources/XPCShared/Models.swift
@@ -47,14 +47,14 @@ public struct EditorContent: Codable {
 }
 
 public struct UpdatedContent: Codable {
-    public init(content: String, newCursor: CursorPosition? = nil, modifications: [Modification]) {
+    public init(content: String, newSelection: CursorRange? = nil, modifications: [Modification]) {
         self.content = content
-        self.newCursor = newCursor
+        self.newSelection = newSelection
         self.modifications = modifications
     }
 
     public var content: String
-    public var newCursor: CursorPosition?
+    public var newSelection: CursorRange?
     public var modifications: [Modification]
 }
 

--- a/Core/Sources/XPCShared/Models.swift
+++ b/Core/Sources/XPCShared/Models.swift
@@ -68,10 +68,16 @@ func selectedCode(in selection: EditorContent.Selection, for lines: [String]) ->
     guard startPosition.line >= 0, startPosition.line < lines.count else { return "" }
     guard startPosition.character >= 0,
           startPosition.character < lines[startPosition.line].count else { return "" }
-    guard endPosition.line >= 0, endPosition.line < lines.count else { return "" }
+    guard endPosition.line >= 0,
+          endPosition.line < lines.count
+            || (endPosition.line == lines.count && endPosition.character == -1)
+    else { return "" }
     guard endPosition.line >= startPosition.line else { return "" }
-    guard endPosition.character >= 0,
-          endPosition.character < lines[endPosition.line].count else { return "" }
+    guard endPosition.character >= -1 else { return "" }
+    
+    if endPosition.line < lines.endIndex {
+        guard endPosition.character < lines[endPosition.line].count else { return "" }
+    }
 
     var code = ""
     if startPosition.line == endPosition.line {
@@ -94,9 +100,11 @@ func selectedCode(in selection: EditorContent.Selection, for lines: [String]) ->
             }
         }
 
-        let endLine = lines[endPosition.line]
-        let endIndex = endLine.index(endLine.startIndex, offsetBy: endPosition.character)
-        code += String(endLine[...endIndex])
+        if endPosition.character >= 0, endPosition.line < lines.endIndex {
+            let endLine = lines[endPosition.line]
+            let endIndex = endLine.index(endLine.startIndex, offsetBy: endPosition.character)
+            code += String(endLine[...endIndex])
+        }
     }
 
     return code

--- a/EditorExtension/Helpers.swift
+++ b/EditorExtension/Helpers.swift
@@ -19,15 +19,15 @@ extension XCSourceEditorCommandInvocation {
     }
 
     func accept(_ updatedContent: UpdatedContent) {
-        if let newCursor = updatedContent.newCursor {
+        if let newSelection = updatedContent.newSelection {
             mutateCompleteBuffer(
                 modifications: updatedContent.modifications,
                 restoringSelections: false
             )
             buffer.selections.removeAllObjects()
             buffer.selections.add(XCSourceTextRange(
-                start: .init(line: newCursor.line, column: newCursor.character),
-                end: .init(line: newCursor.line, column: newCursor.character)
+                start: .init(line: newSelection.start.line, column: newSelection.start.character),
+                end: .init(line: newSelection.end.line, column: newSelection.end.character)
             ))
         } else {
             mutateCompleteBuffer(


### PR DESCRIPTION
- Make the prompt to code window stays after accepting when continuous mode is on.
- Add a key binding to the accept button.
- Fix extracting selection when the whole file is selected.
- When the selection contains multiple line, force the first line to start with col 0.