### PR TITLE
Add id to CustomCommand

### DIFF
--- a/Copilot for Xcode/CustomCommandView.swift
+++ b/Copilot for Xcode/CustomCommandView.swift
@@ -16,8 +16,7 @@ struct CustomCommandView: View {
                 "Real-time Suggestions",
                 "Prefetch Suggestions",
                 "Chat with Selection",
-                "Prompt to Code",
-                "# Custom Commands:",
+                "Prompt to Code"
             ]
 
             return existed + builtin
@@ -65,6 +64,7 @@ struct CustomCommandView: View {
                 Spacer()
                 Button(action: {
                     editingCommand = .init(isNew: true, command: CustomCommand(
+                        commandId: UUID().uuidString,
                         name: "New Command",
                         feature: .chatWithSelection(
                             extraSystemPrompt: nil,
@@ -236,6 +236,7 @@ struct EditCustomCommandView: View {
                 }
 
                 lazy var newCommand = CustomCommand(
+                    commandId: editingCommand?.command.id ?? UUID().uuidString,
                     name: name,
                     feature: {
                         switch commandType {
@@ -283,7 +284,7 @@ struct EditCustomCommandView: View {
                         }
 
                         if let index = settings.customCommands.firstIndex(where: {
-                            $0.name == originalName
+                            $0.id == newCommand.id
                         }) {
                             settings.customCommands[index] = newCommand
                         } else {
@@ -351,10 +352,12 @@ struct CustomCommandView_Preview: PreviewProvider {
             isOpen: .constant(true),
             settings: .init(customCommands: .init(wrappedValue: [
                 .init(
+                    commandId: "1",
                     name: "Explain Code",
                     feature: .chatWithSelection(extraSystemPrompt: nil, prompt: "Hello")
                 ),
                 .init(
+                    commandId: "2",
                     name: "Refactor Code",
                     feature: .promptToCode(
                         extraSystemPrompt: nil,
@@ -363,6 +366,7 @@ struct CustomCommandView_Preview: PreviewProvider {
                     )
                 ),
                 .init(
+                    commandId: "3",
                     name: "Tell Me A Joke",
                     feature: .customChat(systemPrompt: "Joke", prompt: "")
                 ),
@@ -378,6 +382,7 @@ struct EditCustomCommandView_Preview: PreviewProvider {
             editingCommand: .constant(CustomCommandView.EditingCommand(
                 isNew: false,
                 command: .init(
+                    commandId: "4",
                     name: "Explain Code",
                     feature: .promptToCode(
                         extraSystemPrompt: nil,

--- a/Core/Sources/Client/AsyncXPCService.swift
+++ b/Core/Sources/Client/AsyncXPCService.swift
@@ -198,13 +198,13 @@ public struct AsyncXPCService {
     }
 
     public func customCommand(
-        name: String,
+        id: String,
         editorContent: EditorContent
     ) async throws -> UpdatedContent? {
         try await suggestionRequest(
             connection,
             editorContent,
-            { service in { service.customCommand(name: name, editorContent: $0, withReply: $1) } }
+            { service in { service.customCommand(id: id, editorContent: $0, withReply: $1) } }
         )
     }
 }

--- a/Core/Sources/Preferences/CustomCommand.swift
+++ b/Core/Sources/Preferences/CustomCommand.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 public struct CustomCommand: Codable {
     /// The custom command feature.
@@ -10,11 +11,33 @@ public struct CustomCommand: Codable {
         case customChat(systemPrompt: String?, prompt: String?)
     }
 
+    public var id: String { commandId ?? legacyId }
+    public var commandId: String?
     public var name: String
     public var feature: Feature
     
-    public init(name: String, feature: Feature) {
+    public init(commandId: String, name: String, feature: Feature) {
+        self.commandId = commandId
         self.name = name
         self.feature = feature
+    }
+    
+    var legacyId: String {
+        name.sha1HexString
+    }
+}
+
+private extension Digest {
+    var bytes: [UInt8] { Array(makeIterator()) }
+    var data: Data { Data(bytes) }
+
+    var hexStr: String {
+        bytes.map { String(format: "%02X", $0) }.joined()
+    }
+}
+
+private extension String {
+    var sha1HexString: String {
+        Insecure.SHA1.hash(data: data(using: .utf8) ?? Data()).hexStr
     }
 }

--- a/Core/Sources/Preferences/Keys.swift
+++ b/Core/Sources/Preferences/Keys.swift
@@ -227,6 +227,7 @@ public extension UserDefaultPreferenceKeys {
     struct CustomCommandsKey: UserDefaultPreferenceKey {
         public let defaultValue: [CustomCommand] = [
             .init(
+                commandId: "BuiltInCustomCommandExplainSelection",
                 name: "Explain Selection",
                 feature: .chatWithSelection(
                     extraSystemPrompt: nil,
@@ -234,6 +235,7 @@ public extension UserDefaultPreferenceKeys {
                 )
             ),
             .init(
+                commandId: "BuiltInCustomCommandAddDocumentationToSelection",
                 name: "Add Documentation to Selection",
                 feature: .promptToCode(
                     extraSystemPrompt: nil,

--- a/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
+++ b/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift.swift
@@ -25,10 +25,10 @@ public final class GraphicalUserInterfaceController {
                     ))
                 }
             }
-            suggestionWidget.onCustomCommandClicked = { name in
+            suggestionWidget.onCustomCommandClicked = { command in
                 Task {
                     let commandHandler = PseudoCommandHandler()
-                    await commandHandler.handleCustomDomain(name: name)
+                    await commandHandler.handleCustomCommand(command)
                 }
             }
         }

--- a/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/CommentBaseCommandHandler.swift
@@ -183,7 +183,7 @@ struct CommentBaseCommandHandler: SuggestionCommandHandler {
         throw NotSupportedInCommentMode()
     }
     
-    func customCommand(name: String, editor: EditorContent) async throws -> UpdatedContent? {
+    func customCommand(id: String, editor: EditorContent) async throws -> UpdatedContent? {
         throw NotSupportedInCommentMode()
     }
 }

--- a/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/PseudoCommandHandler.swift
@@ -68,11 +68,11 @@ struct PseudoCommandHandler {
         ))
     }
 
-    func handleCustomDomain(name: String) async {
+    func handleCustomCommand(_ command: CustomCommand) async {
         guard let editor = await getEditorContent(sourceEditor: nil)
         else {
             do {
-                try await Environment.triggerAction(name)
+                try await Environment.triggerAction(command.name)
             } catch {
                 let presenter = PresentInWindowSuggestionPresenter()
                 presenter.presentError(error)
@@ -82,7 +82,7 @@ struct PseudoCommandHandler {
 
         let handler = WindowBaseCommandHandler()
         do {
-            try await handler.handleCustomCommand(name: name, editor: editor)
+            try await handler.handleCustomCommand(id: command.id, editor: editor)
         } catch {
             let presenter = PresentInWindowSuggestionPresenter()
             presenter.presentError(error)

--- a/Core/Sources/Service/SuggestionCommandHandler/SuggestionCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/SuggestionCommandHandler.swift
@@ -21,5 +21,5 @@ protocol SuggestionCommandHandler {
     @ServiceActor
     func promptToCode(editor: EditorContent) async throws -> UpdatedContent?
     @ServiceActor
-    func customCommand(name: String, editor: EditorContent) async throws -> UpdatedContent?
+    func customCommand(id: String, editor: EditorContent) async throws -> UpdatedContent?
 }

--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -263,10 +263,10 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
         return nil
     }
 
-    func customCommand(name: String, editor: EditorContent) async throws -> UpdatedContent? {
+    func customCommand(id: String, editor: EditorContent) async throws -> UpdatedContent? {
         Task {
             do {
-                try await handleCustomCommand(name: name, editor: editor)
+                try await handleCustomCommand(id: id, editor: editor)
             } catch {
                 presenter.presentError(error)
             }
@@ -276,13 +276,13 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
 }
 
 extension WindowBaseCommandHandler {
-    func handleCustomCommand(name: String, editor: EditorContent) async throws {
+    func handleCustomCommand(id: String, editor: EditorContent) async throws {
         struct CommandNotFoundError: Error, LocalizedError {
             var errorDescription: String? { "Command not found" }
         }
 
         let availableCommands = UserDefaults.shared.value(for: \.customCommands)
-        guard let command = availableCommands.first(where: { $0.name == name })
+        guard let command = availableCommands.first(where: { $0.id == id })
         else { throw CommandNotFoundError() }
 
         switch command.feature {

--- a/Core/Sources/Service/XPCService.swift
+++ b/Core/Sources/Service/XPCService.swift
@@ -240,12 +240,12 @@ public class XPCService: NSObject, XPCServiceProtocol {
     }
 
     public func customCommand(
-        name: String,
+        id: String,
         editorContent: Data,
         withReply reply: @escaping (Data?, Error?) -> Void
     ) {
         replyWithUpdatedContent(editorContent: editorContent, withReply: reply) { handler, editor in
-            try await handler.customCommand(name: name, editor: editor)
+            try await handler.customCommand(id: id, editor: editor)
         }
     }
 

--- a/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
@@ -40,8 +40,8 @@ public final class SuggestionWidgetController {
                 onOpenChatClicked: { [weak self] in
                     self?.onOpenChatClicked()
                 },
-                onCustomCommandClicked: { [weak self] name in
-                    self?.onCustomCommandClicked(name)
+                onCustomCommandClicked: { [weak self] command in
+                    self?.onCustomCommandClicked(command)
                 }
             )
         )
@@ -104,7 +104,7 @@ public final class SuggestionWidgetController {
     private var colorScheme: ColorScheme = .light
     
     public var onOpenChatClicked: () -> Void = {}
-    public var onCustomCommandClicked: (String) -> Void = { _ in }
+    public var onCustomCommandClicked: (CustomCommand) -> Void = { _ in }
     public var dataSource: SuggestionWidgetDataSource?
 
     public nonisolated init() {

--- a/Core/Sources/SuggestionWidget/WidgetView.swift
+++ b/Core/Sources/SuggestionWidget/WidgetView.swift
@@ -1,4 +1,5 @@
 import Environment
+import Preferences
 import SwiftUI
 
 @MainActor
@@ -17,7 +18,7 @@ struct WidgetView: View {
     @State var isHovering: Bool = false
     @State var processingProgress: Double = 0
     var onOpenChatClicked: () -> Void = {}
-    var onCustomCommandClicked: (String) -> Void = { _ in }
+    var onCustomCommandClicked: (CustomCommand) -> Void = { _ in }
 
     var body: some View {
         Circle().fill(isHovering ? .white.opacity(0.8) : .white.opacity(0.3))
@@ -110,7 +111,7 @@ struct WidgetContextMenu: View {
     @State var projectPath: String?
     var isChatOpen: Bool
     var onOpenChatClicked: () -> Void = {}
-    var onCustomCommandClicked: (String) -> Void = { _ in }
+    var onCustomCommandClicked: (CustomCommand) -> Void = { _ in }
 
     var body: some View {
         Group {
@@ -122,7 +123,7 @@ struct WidgetContextMenu: View {
                         Text("Open Chat")
                     }
                 }
-                
+
                 customCommandMenu()
             }
 
@@ -137,7 +138,7 @@ struct WidgetContextMenu: View {
                         Image(systemName: "checkmark")
                     }
                 }
-                
+
                 Button(action: {
                     realtimeSuggestionToggle.toggle()
                 }) {
@@ -146,7 +147,7 @@ struct WidgetContextMenu: View {
                         Image(systemName: "checkmark")
                     }
                 }
-                
+
                 Button(action: {
                     acceptSuggestionWithAccessibilityAPI.toggle()
                 }, label: {
@@ -155,7 +156,7 @@ struct WidgetContextMenu: View {
                         Image(systemName: "checkmark")
                     }
                 })
-                
+
                 Button(action: {
                     hideCommonPrecedingSpacesInSuggestion.toggle()
                 }, label: {
@@ -164,7 +165,7 @@ struct WidgetContextMenu: View {
                         Image(systemName: "checkmark")
                     }
                 })
-                
+
                 Button(action: {
                     forceOrderWidgetToFront.toggle()
                 }, label: {
@@ -173,7 +174,7 @@ struct WidgetContextMenu: View {
                         Image(systemName: "checkmark")
                     }
                 })
-                
+
                 if let projectPath, disableSuggestionFeatureGlobally {
                     let matchedPath = suggestionFeatureEnabledProjectList.first { path in
                         projectPath.hasPrefix(path)
@@ -221,12 +222,12 @@ struct WidgetContextMenu: View {
             }
         }
     }
-    
+
     func customCommandMenu() -> some View {
         Menu("Custom Commands") {
             ForEach(customCommands, id: \.name) { command in
                 Button(action: {
-                    onCustomCommandClicked(command.name)
+                    onCustomCommandClicked(command)
                 }) {
                     Text(command.name)
                 }

--- a/Core/Sources/XPCShared/XPCServiceProtocol.swift
+++ b/Core/Sources/XPCShared/XPCServiceProtocol.swift
@@ -46,7 +46,7 @@ public protocol XPCServiceProtocol {
         withReply reply: @escaping (Data?, Error?) -> Void
     )
     func customCommand(
-        name: String,
+        id: String,
         editorContent: Data,
         withReply reply: @escaping (Data?, Error?) -> Void
     )

--- a/EditorExtension/CustomCommand.swift
+++ b/EditorExtension/CustomCommand.swift
@@ -14,7 +14,7 @@ class CustomCommand: NSObject, XCSourceEditorCommand, CommandType {
             do {
                 let service = try getService()
                 if let content = try await service.customCommand(
-                    name: customCommandMap[invocation.commandIdentifier] ?? "",
+                    id: customCommandMap[invocation.commandIdentifier] ?? "",
                     editorContent: .init(invocation)
                 ) {
                     invocation.accept(content)

--- a/EditorExtension/SourceEditorExtension.swift
+++ b/EditorExtension/SourceEditorExtension.swift
@@ -75,40 +75,17 @@ func makeCommandDefinition(_ commandType: CommandType)
 }
 
 func customCommands() -> [[XCSourceEditorCommandDefinitionKey: Any]] {
-    let definitions = UserDefaults.shared.value(for: \.customCommands).map {
-        [
-            XCSourceEditorCommandDefinitionKey.classNameKey: CustomCommand.className(),
-            XCSourceEditorCommandDefinitionKey
-                .identifierKey: identifierPrefix + "CustomCommand\($0.name.sha1HexString)",
-            .nameKey: $0.name,
-        ]
+    var definitions = [[XCSourceEditorCommandDefinitionKey: String]]()
+    for command in UserDefaults.shared.value(for: \.customCommands) {
+        let identifier = identifierPrefix + "CustomCommand\(command.id)"
+        definitions.append([
+            .classNameKey: CustomCommand.className(),
+            .identifierKey: identifier,
+            .nameKey: command.name,
+        ])
+        
+        customCommandMap[identifier] = command.id
     }
-
-    for item in definitions {
-        let name = item[.nameKey]
-        let identifier = item[.identifierKey]
-        if let identifier {
-            customCommandMap[identifier] = name
-        }
-    }
-
+    
     return definitions
-}
-
-import CryptoKit
-
-// CryptoKit.Digest utils
-extension Digest {
-    var bytes: [UInt8] { Array(makeIterator()) }
-    var data: Data { Data(bytes) }
-
-    var hexStr: String {
-        bytes.map { String(format: "%02X", $0) }.joined()
-    }
-}
-
-extension String {
-    var sha1HexString: String {
-        Insecure.SHA1.hash(data: data(using: .utf8) ?? Data()).hexStr
-    }
 }


### PR DESCRIPTION
Added a `commandId` field to `CustomCommand`, which should be a UUID string. For old commands that don't have an id, they will use the SHA1 of the name as id, which was used in 0.13.2, to avoid re-configuration of keybindings.