### PR TITLE
Real time suggestion tweak

### DIFF
--- a/Core/Sources/CodeiumService/CodeiumService.swift
+++ b/Core/Sources/CodeiumService/CodeiumService.swift
@@ -230,7 +230,7 @@ extension CodeiumSuggestionService: CodeiumSuggestionServiceType {
 
         let relativePath = getRelativePath(of: fileURL)
 
-        let request = CodeiumRequest.GetCompletion(requestBody: .init(
+        let request = await CodeiumRequest.GetCompletion(requestBody: .init(
             metadata: try getMetadata(),
             document: .init(
                 absolute_path: fileURL.path,
@@ -306,7 +306,7 @@ extension CodeiumSuggestionService: CodeiumSuggestionServiceType {
 
     public func notifyOpenTextDocument(fileURL: URL, content: String) async throws {
         let relativePath = getRelativePath(of: fileURL)
-        openedDocumentPool.openDocument(
+        await openedDocumentPool.openDocument(
             url: fileURL,
             relativePath: relativePath,
             content: content
@@ -315,7 +315,7 @@ extension CodeiumSuggestionService: CodeiumSuggestionServiceType {
 
     public func notifyChangeTextDocument(fileURL: URL, content: String) async throws {
         let relativePath = getRelativePath(of: fileURL)
-        openedDocumentPool.updateDocument(
+        await openedDocumentPool.updateDocument(
             url: fileURL,
             relativePath: relativePath,
             content: content
@@ -323,7 +323,7 @@ extension CodeiumSuggestionService: CodeiumSuggestionServiceType {
     }
 
     public func notifyCloseTextDocument(fileURL: URL) async throws {
-        openedDocumentPool.closeDocument(url: fileURL)
+        await openedDocumentPool.closeDocument(url: fileURL)
     }
 }
 

--- a/Core/Sources/CodeiumService/OpendDocumentPool.swift
+++ b/Core/Sources/CodeiumService/OpendDocumentPool.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private let maxSize: Int = 1_000_000 // Byte
 
-final class OpenedDocumentPool {
+actor OpenedDocumentPool {
     var openedDocuments = [URL: OpenedDocument]()
 
     func getOtherDocuments(exceptURL: URL) -> [OpenedDocument] {

--- a/Core/Sources/GitHubCopilotService/GitHubCopilotService.swift
+++ b/Core/Sources/GitHubCopilotService/GitHubCopilotService.swift
@@ -31,6 +31,7 @@ public protocol GitHubCopilotSuggestionServiceType {
     func notifyChangeTextDocument(fileURL: URL, content: String) async throws
     func notifyCloseTextDocument(fileURL: URL) async throws
     func notifySaveTextDocument(fileURL: URL) async throws
+    func cancelRequest() async
 }
 
 protocol GitHubCopilotLSP {
@@ -310,6 +311,10 @@ public final class GitHubCopilotSuggestionService: GitHubCopilotBaseService,
         ongoingTasks.insert(task)
 
         return try await task.value
+    }
+    
+    public func cancelRequest() async {
+        await localProcessServer?.cancelOngoingTasks()
     }
 
     public func notifyAccepted(_ completion: CodeSuggestion) async {

--- a/Core/Sources/Service/RealtimeSuggestionController.swift
+++ b/Core/Sources/Service/RealtimeSuggestionController.swift
@@ -191,7 +191,7 @@ public class RealtimeSuggestionController {
             if event.type == .keyDown {
                 await cancelInFlightTasks()
             } else {
-                let task = Task {
+                Task {
                     #warning(
                         "TODO: Any method to avoid using AppleScript to check that completion panel is presented?"
                     )
@@ -200,7 +200,6 @@ public class RealtimeSuggestionController {
                         self.triggerPrefetchDebounced(force: true)
                     }
                 }
-                inflightRealtimeSuggestionsTasks.insert(task)
             }
         }
     }
@@ -246,18 +245,6 @@ public class RealtimeSuggestionController {
                 group.addTask {
                     await workspace.cancelInFlightRealtimeSuggestionRequests()
                 }
-            }
-            group.addTask {
-                await { @ServiceActor in
-                    inflightRealtimeSuggestionsTasks.forEach {
-                        if $0 == excluding { return }
-                        $0.cancel()
-                    }
-                    inflightRealtimeSuggestionsTasks.removeAll()
-                    if let excluded = excluding {
-                        inflightRealtimeSuggestionsTasks.insert(excluded)
-                    }
-                }()
             }
         }
     }

--- a/Core/Sources/Service/RealtimeSuggestionController.swift
+++ b/Core/Sources/Service/RealtimeSuggestionController.swift
@@ -171,12 +171,6 @@ public class RealtimeSuggestionController {
     func handleHIDEvent(event: CGEvent) async {
         guard await Environment.isXcodeActive() else { return }
 
-        // Mouse clicks should cancel in-flight tasks.
-        if [CGEventType.rightMouseDown, .leftMouseDown].contains(event.type) {
-            await cancelInFlightTasks()
-            return
-        }
-
         let keycode = Int(event.getIntegerValueField(.keyboardEventKeycode))
         let escape = 0x35
 

--- a/Core/Sources/Service/RealtimeSuggestionController.swift
+++ b/Core/Sources/Service/RealtimeSuggestionController.swift
@@ -26,7 +26,7 @@ public class RealtimeSuggestionController {
     private var activeApplicationMonitorTask: Task<Void, Error>?
     private var editorObservationTask: Task<Void, Error>?
     private var focusedUIElement: AXUIElement?
-    private var sourceEditor: AXUIElement?
+    private var sourceEditor: SourceEditor?
 
     var isCommentMode: Bool {
         UserDefaults.shared.value(for: \.suggestionPresentationMode) == .comment
@@ -116,7 +116,7 @@ public class RealtimeSuggestionController {
         }
 
         guard focusElementType == "Source Editor" else { return }
-        sourceEditor = focusElement
+        sourceEditor = SourceEditor(runningApplication: activeXcode, element: focusElement)
 
         editorObservationTask?.cancel()
         editorObservationTask = nil
@@ -138,11 +138,7 @@ public class RealtimeSuggestionController {
                     self.triggerPrefetchDebounced()
                     await self.notifyEditingFileChange(editor: focusElement)
                 case kAXSelectedTextChangedNotification:
-                    guard let editor = sourceEditor else { continue }
-                    let sourceEditor = SourceEditor(
-                        runningApplication: activeXcode,
-                        element: editor
-                    )
+                    guard let sourceEditor else { continue }
                     await PseudoCommandHandler()
                         .invalidateRealtimeSuggestionsIfNeeded(sourceEditor: sourceEditor)
                 default:

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -67,6 +67,20 @@ final class Filespace {
     func refreshUpdateTime() {
         lastSuggestionUpdateTime = Environment.now()
     }
+    
+    func validateSuggestions(lines: [String], cursorPosition: CursorPosition) -> Bool {
+        if cursorPosition.line != suggestionSourceSnapshot.cursorPosition.line {
+            reset()
+            return false
+        }
+        
+        guard cursorPosition.line >= 0, cursorPosition.line < lines.count else {
+            reset()
+            return false
+        }
+        
+        return true
+    }
 }
 
 // MARK: - Workspace

--- a/Core/Sources/Service/Workspace.swift
+++ b/Core/Sources/Service/Workspace.swift
@@ -79,6 +79,13 @@ final class Filespace {
             return false
         }
         
+        let editingLine = lines[cursorPosition.line].dropLast(1) // dropping \n
+        let suggestionFirstLine = presentingSuggestion?.text.split(separator: "\n").first ?? ""
+        if !suggestionFirstLine.hasPrefix(editingLine) {
+            reset()
+            return false
+        }
+        
         return true
     }
 }

--- a/Core/Sources/SuggestionInjector/SuggestionInjector.swift
+++ b/Core/Sources/SuggestionInjector/SuggestionInjector.swift
@@ -104,11 +104,11 @@ public struct SuggestionInjector {
             )
         }
 
-        // if the suggestion is only appeding new lines and spaces, return without modification
+        // if the suggestion is only appending new lines and spaces, return without modification
         if completion.text.dropFirst(commonPrefix.count)
             .allSatisfy({ $0.isWhitespace || $0.isNewline }) { return }
 
-        // determin if it's inserted to the current line or the next line
+        // determine if it's inserted to the current line or the next line
         let lineIndex = start.line + {
             guard let existedLine else { return 0 }
             if existedLine.isEmptyOrNewLine { return 1 }

--- a/Core/Sources/SuggestionInjector/SuggestionInjector.swift
+++ b/Core/Sources/SuggestionInjector/SuggestionInjector.swift
@@ -154,6 +154,7 @@ public struct SuggestionInjector {
 
         var toBeInserted = suggestionContent.breakLines(appendLineBreakToLastLine: true)
 
+        // prepending prefix text not in range if needed.
         if let firstRemovedLine,
            !firstRemovedLine.isEmptyOrNewLine,
            start.character > 0,
@@ -175,8 +176,16 @@ public struct SuggestionInjector {
             )
         }
 
+        // appending suffix text not in range if needed.
         let cursorCol = toBeInserted[toBeInserted.endIndex - 1].count - 1
+        let skipAppendingDueToContinueTyping = {
+            guard let first = toBeInserted.first?.dropLast(1), !first.isEmpty else { return false }
+            let droppedLast = lastRemovedLine?.dropLast(1)
+            guard let droppedLast, !droppedLast.isEmpty else { return false }
+            return first.hasPrefix(droppedLast)
+        }()
         if let lastRemovedLine,
+           !skipAppendingDueToContinueTyping,
            !lastRemovedLine.isEmptyOrNewLine,
            end.character >= 0,
            end.character - 1 < lastRemovedLine.count,
@@ -191,6 +200,7 @@ public struct SuggestionInjector {
                 toBeInserted[toBeInserted.endIndex - 1].removeLast(1)
             }
             let leftover = lastRemovedLine[leftoverRange]
+            
             toBeInserted[toBeInserted.endIndex - 1]
                 .append(contentsOf: leftover)
         }

--- a/Core/Sources/SuggestionService/CodeiumSuggestionProvider.swift
+++ b/Core/Sources/SuggestionService/CodeiumSuggestionProvider.swift
@@ -70,5 +70,10 @@ extension CodeiumSuggestionProvider {
     }
 
     func notifySaveTextDocument(fileURL: URL) async throws {}
+    
+    func cancelRequest() async {
+        await (try? createCodeiumServiceIfNeeded())?
+            .cancelRequest()
+    }
 }
 

--- a/Core/Sources/SuggestionService/GitHubCopilotSuggestionProvider.swift
+++ b/Core/Sources/SuggestionService/GitHubCopilotSuggestionProvider.swift
@@ -73,5 +73,10 @@ extension GitHubCopilotSuggestionProvider {
         try await (try? createGitHubCopilotServiceIfNeeded())?
             .notifySaveTextDocument(fileURL: fileURL)
     }
+    
+    func cancelRequest() async {
+        await (try? createGitHubCopilotServiceIfNeeded())?
+            .cancelRequest()
+    }
 }
 

--- a/Core/Sources/SuggestionService/SuggestionService.swift
+++ b/Core/Sources/SuggestionService/SuggestionService.swift
@@ -20,6 +20,7 @@ public protocol SuggestionServiceType {
     func notifyChangeTextDocument(fileURL: URL, content: String) async throws
     func notifyCloseTextDocument(fileURL: URL) async throws
     func notifySaveTextDocument(fileURL: URL) async throws
+    func cancelRequest() async
 }
 
 protocol SuggestionServiceProvider: SuggestionServiceType {}
@@ -115,6 +116,10 @@ public extension SuggestionService {
 
     func notifySaveTextDocument(fileURL: URL) async throws {
         try await suggestionProvider.notifySaveTextDocument(fileURL: fileURL)
+    }
+    
+    func cancelRequest() async {
+        await suggestionProvider.cancelRequest()
     }
 }
 

--- a/Core/Sources/XcodeInspector/SourceEditor.swift
+++ b/Core/Sources/XcodeInspector/SourceEditor.swift
@@ -34,7 +34,7 @@ public class SourceEditor {
                 content: content,
                 lines: split,
                 selections: [range],
-                cursorPosition: range.end,
+                cursorPosition: range.start,
                 lineAnnotations: lineAnnotations
             )
         }

--- a/Core/Tests/ServiceTests/Environment.swift
+++ b/Core/Tests/ServiceTests/Environment.swift
@@ -34,6 +34,10 @@ func completion(text: String, range: CursorRange, uuid: String = "") -> CodeSugg
 }
 
 class MockSuggestionService: GitHubCopilotSuggestionServiceType {
+    func cancelRequest() async {
+        fatalError()
+    }
+    
     func notifyOpenTextDocument(fileURL: URL, content: String) async throws {
         fatalError()
     }

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The app can provide real-time code suggestions based on the files you have opene
 
 If you're working on a company project and don't want the suggestion feature to be triggered, you can globally disable it and choose to enable it only for specific projects. 
 
-Whenever you stop typing for a few milliseconds, the app will automatically fetch suggestions for you, you can cancel this by clicking the mouse, or pressing **Escape** or the **arrow keys**.
+Whenever your code is updated, the app will automatically fetch suggestions for you, you can cancel this by pressing **Escape**.
 
 *: If a file is already open before the helper app launches, you will need to switch to those files in order to send the open file notification. 
 


### PR DESCRIPTION
- Invalidate suggestions when they are no longer relevant to the source code and the text cursor’s current position. #197 
- Keep the suggestion when user is typing as the suggestion suggests.
- Remove the request cancellation when users press arrow keys or click with the mouse.
- Simpler implementation of request cancellation.