### PR TITLE
Persisted chat

### DIFF
--- a/Core/Sources/ChatGPTChatTab/ChatContextMenu.swift
+++ b/Core/Sources/ChatGPTChatTab/ChatContextMenu.swift
@@ -3,7 +3,7 @@ import SharedUIComponents
 import SwiftUI
 
 struct ChatContextMenu: View {
-    let chat: ChatProvider
+    @ObservedObject var chat: ChatProvider
     @AppStorage(\.customCommands) var customCommands
 
     var body: some View {

--- a/Core/Sources/ChatService/ChatService.swift
+++ b/Core/Sources/ChatService/ChatService.swift
@@ -7,7 +7,7 @@ import Preferences
 
 public final class ChatService: ObservableObject {
     public let memory: ContextAwareAutoManagedChatGPTMemory
-    public let configuration: ChatGPTConfiguration
+    public let configuration: OverridingChatGPTConfiguration
     public let chatGPTService: any ChatGPTServiceType
     public var allPluginCommands: [String] { allPlugins.map { $0.command } }
     @Published public internal(set) var isReceivingMessage = false
@@ -20,7 +20,7 @@ public final class ChatService: ObservableObject {
 
     init<T: ChatGPTServiceType>(
         memory: ContextAwareAutoManagedChatGPTMemory,
-        configuration: ChatGPTConfiguration,
+        configuration: OverridingChatGPTConfiguration,
         chatGPTService: T
     ) {
         self.memory = memory

--- a/Core/Sources/Service/GUI/ChatTabFactory.swift
+++ b/Core/Sources/Service/GUI/ChatTabFactory.swift
@@ -11,9 +11,7 @@ import XcodeInspector
 import ProChatTabs
 
 enum ChatTabFactory {
-    static func chatTabBuilderCollection(
-        openTab: @escaping (any ChatTab) -> Void
-    ) -> [ChatTabBuilderCollection] {
+    static func chatTabBuilderCollection() -> [ChatTabBuilderCollection] {
         func folderIfNeeded(
             _ builders: [any ChatTabBuilder],
             title: String
@@ -88,8 +86,7 @@ enum ChatTabFactory {
                         try await service.modifyCode(prompt: instruction ?? "Modify content.")
                         return service.code
                     }
-                },
-                handleNewTab: openTab
+                }
             )), title: BrowserChatTab.name),
         ].compactMap { $0 }
 
@@ -100,9 +97,7 @@ enum ChatTabFactory {
 #else
 
 enum ChatTabFactory {
-    static func chatTabBuilderCollection(
-        openTab: @escaping (any ChatTab) -> Void
-    ) -> [ChatTabBuilderCollection] {
+    static func chatTabBuilderCollection() -> [ChatTabBuilderCollection] {
         func folderIfNeeded(
             _ builders: [any ChatTabBuilder],
             title: String

--- a/Core/Sources/Service/GUI/ChatTabFactory.swift
+++ b/Core/Sources/Service/GUI/ChatTabFactory.swift
@@ -25,72 +25,81 @@ enum ChatTabFactory {
 
         let collection = [
             folderIfNeeded(ChatGPTChatTab.chatBuilders(), title: ChatGPTChatTab.name),
-            folderIfNeeded(BrowserChatTab.chatBuilders(externalDependency: .init(
-                getEditorContent: {
-                    guard let editor = XcodeInspector.shared.focusedEditor else {
-                        return .init(selectedText: "", language: "", fileContent: "")
-                    }
-                    let content = editor.content
-                    return .init(
-                        selectedText: content.selectedContent,
-                        language: languageIdentifierFromFileURL(
-                            XcodeInspector.shared
-                                .activeDocumentURL
-                        )
-                        .rawValue,
-                        fileContent: content.content
-                    )
-                },
-                handleCustomCommand: { command, prompt in
-                    switch command.feature {
-                    case let .chatWithSelection(extraSystemPrompt, _, useExtraSystemPrompt):
-                        let service = ChatService()
-                        return try await service.processMessage(
-                            systemPrompt: nil,
-                            extraSystemPrompt: (useExtraSystemPrompt ?? false) ? extraSystemPrompt :
-                                nil,
-                            prompt: prompt
-                        )
-                    case let .customChat(systemPrompt, _):
-                        let service = ChatService()
-                        return try await service.processMessage(
-                            systemPrompt: systemPrompt,
-                            extraSystemPrompt: nil,
-                            prompt: prompt
-                        )
-                    case let .singleRoundDialog(
-                        systemPrompt,
-                        overwriteSystemPrompt,
-                        _,
-                        _
-                    ):
-                        let service = ChatService()
-                        return try await service.handleSingleRoundDialogCommand(
-                            systemPrompt: systemPrompt,
-                            overwriteSystemPrompt: overwriteSystemPrompt ?? false,
-                            prompt: prompt
-                        )
-                    case let .promptToCode(extraSystemPrompt, instruction, _, _):
-                        let service = PromptToCodeService(
-                            code: prompt,
-                            selectionRange: .outOfScope,
-                            language: .plaintext,
-                            identSize: 4,
-                            usesTabsForIndentation: true,
-                            projectRootURL: .init(fileURLWithPath: "/"),
-                            fileURL: .init(fileURLWithPath: "/"),
-                            allCode: prompt,
-                            extraSystemPrompt: extraSystemPrompt,
-                            generateDescriptionRequirement: false
-                        )
-                        try await service.modifyCode(prompt: instruction ?? "Modify content.")
-                        return service.code
-                    }
-                }
-            )), title: BrowserChatTab.name),
+            folderIfNeeded(
+                BrowserChatTab.chatBuilders(
+                    externalDependency: externalDependenciesForBrowserChatTab()
+                ),
+                title: BrowserChatTab.name
+            ),
         ].compactMap { $0 }
 
         return collection
+    }
+
+    static func externalDependenciesForBrowserChatTab() -> BrowserChatTab.ExternalDependency {
+        .init(
+            getEditorContent: {
+                guard let editor = XcodeInspector.shared.focusedEditor else {
+                    return .init(selectedText: "", language: "", fileContent: "")
+                }
+                let content = editor.content
+                return .init(
+                    selectedText: content.selectedContent,
+                    language: languageIdentifierFromFileURL(
+                        XcodeInspector.shared
+                            .activeDocumentURL
+                    )
+                    .rawValue,
+                    fileContent: content.content
+                )
+            },
+            handleCustomCommand: { command, prompt in
+                switch command.feature {
+                case let .chatWithSelection(extraSystemPrompt, _, useExtraSystemPrompt):
+                    let service = ChatService()
+                    return try await service.processMessage(
+                        systemPrompt: nil,
+                        extraSystemPrompt: (useExtraSystemPrompt ?? false) ? extraSystemPrompt :
+                            nil,
+                        prompt: prompt
+                    )
+                case let .customChat(systemPrompt, _):
+                    let service = ChatService()
+                    return try await service.processMessage(
+                        systemPrompt: systemPrompt,
+                        extraSystemPrompt: nil,
+                        prompt: prompt
+                    )
+                case let .singleRoundDialog(
+                    systemPrompt,
+                    overwriteSystemPrompt,
+                    _,
+                    _
+                ):
+                    let service = ChatService()
+                    return try await service.handleSingleRoundDialogCommand(
+                        systemPrompt: systemPrompt,
+                        overwriteSystemPrompt: overwriteSystemPrompt ?? false,
+                        prompt: prompt
+                    )
+                case let .promptToCode(extraSystemPrompt, instruction, _, _):
+                    let service = PromptToCodeService(
+                        code: prompt,
+                        selectionRange: .outOfScope,
+                        language: .plaintext,
+                        identSize: 4,
+                        usesTabsForIndentation: true,
+                        projectRootURL: .init(fileURLWithPath: "/"),
+                        fileURL: .init(fileURLWithPath: "/"),
+                        allCode: prompt,
+                        extraSystemPrompt: extraSystemPrompt,
+                        generateDescriptionRequirement: false
+                    )
+                    try await service.modifyCode(prompt: instruction ?? "Modify content.")
+                    return service.code
+                }
+            }
+        )
     }
 }
 

--- a/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift
+++ b/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift
@@ -298,23 +298,22 @@ extension ChatTabPool {
         _ data: ChatTabPersistent.RestorableTabData
     ) async throws -> (any ChatTab, ChatTabInfo)? {
         let info = ChatTabInfo(id: data.id, title: "")
-        switch data.name {
-        case ChatGPTChatTab.name:
+        
+        let chatTapTypes: [any ChatTab.Type] = [
+            ChatGPTChatTab.self,
+            BrowserChatTab.self,
+            EmptyChatTab.self
+        ]
+        
+        for type in chatTapTypes {
+            guard data.name == type.name else { continue }
             guard let builder = try? await ChatGPTChatTab.restore(
                 from: data.data,
                 externalDependency: ()
             ) else { break }
             return createTab(from: builder)
-        case BrowserChatTab.name:
-            guard let builder = try? await BrowserChatTab.restore(
-                from: data.data,
-                externalDependency: ()
-            ) else { break }
-            return createTab(from: builder)
-        default:
-            break
         }
-
+        
         guard let builder = try? await EmptyChatTab.restore(
             from: data.data, externalDependency: ()
         ) else {

--- a/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift
+++ b/Core/Sources/Service/GUI/GraphicalUserInterfaceController.swift
@@ -16,17 +16,17 @@ struct GUI: ReducerProtocol {
         var suggestionWidgetState = WidgetFeature.State()
 
         var chatTabGroup: ChatPanelFeature.ChatTabGroup {
-            get { suggestionWidgetState.chatPanelState.chatTapGroup }
-            set { suggestionWidgetState.chatPanelState.chatTapGroup = newValue }
+            get { suggestionWidgetState.chatPanelState.chatTabGroup }
+            set { suggestionWidgetState.chatPanelState.chatTabGroup = newValue }
         }
 
         #if canImport(ChatTabPersistent)
         var persistentState: ChatTabPersistent.State {
             get {
-                .init(chatTabInfo: suggestionWidgetState.chatPanelState.chatTapGroup.tabInfo)
+                .init(chatTabInfo: chatTabGroup.tabInfo)
             }
             set {
-                suggestionWidgetState.chatPanelState.chatTapGroup.tabInfo = newValue.chatTabInfo
+                chatTabGroup.tabInfo = newValue.chatTabInfo
             }
         }
         #endif

--- a/Core/Sources/SuggestionWidget/ChatWindowView.swift
+++ b/Core/Sources/SuggestionWidget/ChatWindowView.swift
@@ -23,7 +23,7 @@ struct ChatWindowView: View {
                 OverallState(
                     isPanelDisplayed: $0.isPanelDisplayed,
                     colorScheme: $0.colorScheme,
-                    selectedTabId: $0.chatTapGroup.selectedTabId
+                    selectedTabId: $0.chatTabGroup.selectedTabId
                 )
             }
         ) { viewStore in
@@ -165,9 +165,9 @@ struct ChatTabBar: View {
         WithViewStore(
             store,
             observe: { TabBarState(
-                tabInfo: $0.chatTapGroup.tabInfo,
-                selectedTabId: $0.chatTapGroup.selectedTabId
-                    ?? $0.chatTapGroup.tabInfo.first?.id ?? ""
+                tabInfo: $0.chatTabGroup.tabInfo,
+                selectedTabId: $0.chatTabGroup.selectedTabId
+                    ?? $0.chatTabGroup.tabInfo.first?.id ?? ""
             ) }
         ) { viewStore in
             HStack(spacing: 0) {
@@ -217,7 +217,7 @@ struct ChatTabBar: View {
     @ViewBuilder
     var createButton: some View {
         Menu {
-            WithViewStore(store, observe: { $0.chatTapGroup.tabCollection }) { viewStore in
+            WithViewStore(store, observe: { $0.chatTabGroup.tabCollection }) { viewStore in
                 ForEach(0..<viewStore.state.endIndex, id: \.self) { index in
                     switch viewStore.state[index] {
                     case let .kind(kind):
@@ -321,9 +321,9 @@ struct ChatTabContainer: View {
             store,
             observe: {
                 TabContainerState(
-                    tabInfo: $0.chatTapGroup.tabInfo,
-                    selectedTabId: $0.chatTapGroup.selectedTabId
-                        ?? $0.chatTapGroup.tabInfo.first?.id ?? ""
+                    tabInfo: $0.chatTabGroup.tabInfo,
+                    selectedTabId: $0.chatTabGroup.selectedTabId
+                        ?? $0.chatTabGroup.tabInfo.first?.id ?? ""
                 )
             }
         ) { viewStore in
@@ -424,7 +424,7 @@ struct ChatWindowView_Previews: PreviewProvider {
         ChatWindowView(
             store: .init(
                 initialState: .init(
-                    chatTapGroup: .init(
+                    chatTabGroup: .init(
                         tabInfo: [
                             .init(id: "1", title: "Fake"),
                             .init(id: "2", title: "Empty-2"),

--- a/Core/Sources/SuggestionWidget/ChatWindowView.swift
+++ b/Core/Sources/SuggestionWidget/ChatWindowView.swift
@@ -386,6 +386,14 @@ class FakeChatTab: ChatTab {
         )
     }
 
+    func restorableState() async -> Data {
+        return Data()
+    }
+
+    static func restore(from data: Data, externalDependency: ()) async throws -> any ChatTab {
+        return FakeChatTab(id: "id", title: "Title")
+    }
+
     override init(id: String, title: String) {
         super.init(id: id, title: title)
     }

--- a/Core/Sources/SuggestionWidget/ChatWindowView.swift
+++ b/Core/Sources/SuggestionWidget/ChatWindowView.swift
@@ -225,7 +225,7 @@ struct ChatTabBar: View {
                             store.send(.createNewTapButtonClicked(kind: kind))
                         }) {
                             Text(kind.title)
-                        }.disabled(!kind.builder.buildable)
+                        }.disabled(kind.builder is DisabledChatTabBuilder)
                     case let .folder(title, list):
                         Menu {
                             ForEach(0..<list.endIndex, id: \.self) { index in
@@ -364,9 +364,8 @@ class FakeChatTab: ChatTab {
 
     struct Builder: ChatTabBuilder {
         var title: String = "Title"
-        var buildable: Bool { true }
 
-        func build(store: StoreOf<ChatTabItem>) -> any ChatTab {
+        func build(store: StoreOf<ChatTabItem>) async -> (any ChatTab)? {
             return FakeChatTab(store: store)
         }
     }
@@ -395,10 +394,9 @@ class FakeChatTab: ChatTab {
 
     static func restore(
         from data: Data,
-        store: StoreOf<ChatTabItem>,
         externalDependency: ()
-    ) async throws -> any ChatTab {
-        return FakeChatTab(store: store)
+    ) async throws -> any ChatTabBuilder {
+        return Builder()
     }
 
     convenience init(id: String, title: String) {

--- a/Core/Sources/SuggestionWidget/FeatureReducers/ChatPanelFeature.swift
+++ b/Core/Sources/SuggestionWidget/FeatureReducers/ChatPanelFeature.swift
@@ -45,7 +45,7 @@ public struct ChatPanelFeature: ReducerProtocol {
     }
 
     public struct State: Equatable {
-        public var chatTapGroup = ChatTabGroup()
+        public var chatTabGroup = ChatTabGroup()
         var colorScheme: ColorScheme = .light
         var isPanelDisplayed = false
         var chatPanelInASeparateWindow = false
@@ -90,7 +90,7 @@ public struct ChatPanelFeature: ReducerProtocol {
                 }
 
             case .closeActiveTabClicked:
-                if let id = state.chatTapGroup.selectedTabId {
+                if let id = state.chatTabGroup.selectedTabId {
                     return .run { send in
                         await send(.closeTabButtonClicked(id: id))
                     }
@@ -121,95 +121,95 @@ public struct ChatPanelFeature: ReducerProtocol {
                 }
 
             case let .updateChatTabInfo(chatTabInfo):
-                let previousSelectedIndex = state.chatTapGroup.tabInfo
-                    .firstIndex(where: { $0.id == state.chatTapGroup.selectedTabId })
-                state.chatTapGroup.tabInfo = chatTabInfo
-                if !chatTabInfo.contains(where: { $0.id == state.chatTapGroup.selectedTabId }) {
+                let previousSelectedIndex = state.chatTabGroup.tabInfo
+                    .firstIndex(where: { $0.id == state.chatTabGroup.selectedTabId })
+                state.chatTabGroup.tabInfo = chatTabInfo
+                if !chatTabInfo.contains(where: { $0.id == state.chatTabGroup.selectedTabId }) {
                     if let previousSelectedIndex {
                         let proposedSelectedIndex = previousSelectedIndex - 1
                         if proposedSelectedIndex >= 0,
                            proposedSelectedIndex < chatTabInfo.endIndex
                         {
-                            state.chatTapGroup.selectedTabId = chatTabInfo[proposedSelectedIndex].id
+                            state.chatTabGroup.selectedTabId = chatTabInfo[proposedSelectedIndex].id
                         } else {
-                            state.chatTapGroup.selectedTabId = chatTabInfo.first?.id
+                            state.chatTabGroup.selectedTabId = chatTabInfo.first?.id
                         }
                     } else {
-                        state.chatTapGroup.selectedTabId = nil
+                        state.chatTabGroup.selectedTabId = nil
                     }
                 }
                 return .none
 
             case let .closeTabButtonClicked(id):
-                let firstIndex = state.chatTapGroup.tabInfo.firstIndex { $0.id == id }
+                let firstIndex = state.chatTabGroup.tabInfo.firstIndex { $0.id == id }
                 let nextIndex = {
                     guard let firstIndex else { return 0 }
                     let nextIndex = firstIndex - 1
                     return max(nextIndex, 0)
                 }()
-                state.chatTapGroup.tabInfo.removeAll { $0.id == id }
-                if state.chatTapGroup.tabInfo.isEmpty {
+                state.chatTabGroup.tabInfo.removeAll { $0.id == id }
+                if state.chatTabGroup.tabInfo.isEmpty {
                     state.isPanelDisplayed = false
                 }
-                if nextIndex < state.chatTapGroup.tabInfo.count {
-                    state.chatTapGroup.selectedTabId = state.chatTapGroup.tabInfo[nextIndex].id
+                if nextIndex < state.chatTabGroup.tabInfo.count {
+                    state.chatTabGroup.selectedTabId = state.chatTabGroup.tabInfo[nextIndex].id
                 } else {
-                    state.chatTapGroup.selectedTabId = nil
+                    state.chatTabGroup.selectedTabId = nil
                 }
                 return .none
 
             case .createNewTapButtonHovered:
-                state.chatTapGroup.tabCollection = chatTabBuilderCollection()
+                state.chatTabGroup.tabCollection = chatTabBuilderCollection()
                 return .none
 
             case .createNewTapButtonClicked:
                 return .none // handled elsewhere
 
             case let .tabClicked(id):
-                guard state.chatTapGroup.tabInfo.contains(where: { $0.id == id }) else {
-                    state.chatTapGroup.selectedTabId = nil
+                guard state.chatTabGroup.tabInfo.contains(where: { $0.id == id }) else {
+                    state.chatTabGroup.selectedTabId = nil
                     return .none
                 }
-                state.chatTapGroup.selectedTabId = id
+                state.chatTabGroup.selectedTabId = id
                 return .none
 
             case let .appendAndSelectTab(tab):
-                guard !state.chatTapGroup.tabInfo.contains(where: { $0.id == tab.id })
+                guard !state.chatTabGroup.tabInfo.contains(where: { $0.id == tab.id })
                 else { return .none }
-                state.chatTapGroup.tabInfo.append(tab)
-                state.chatTapGroup.selectedTabId = tab.id
+                state.chatTabGroup.tabInfo.append(tab)
+                state.chatTabGroup.selectedTabId = tab.id
                 return .none
 
             case .switchToNextTab:
-                let selectedId = state.chatTapGroup.selectedTabId
-                guard let index = state.chatTapGroup.tabInfo
+                let selectedId = state.chatTabGroup.selectedTabId
+                guard let index = state.chatTabGroup.tabInfo
                     .firstIndex(where: { $0.id == selectedId })
                 else { return .none }
                 let nextIndex = index + 1
-                if nextIndex >= state.chatTapGroup.tabInfo.endIndex {
+                if nextIndex >= state.chatTabGroup.tabInfo.endIndex {
                     return .none
                 }
-                let targetId = state.chatTapGroup.tabInfo[nextIndex].id
-                state.chatTapGroup.selectedTabId = targetId
+                let targetId = state.chatTabGroup.tabInfo[nextIndex].id
+                state.chatTabGroup.selectedTabId = targetId
                 return .none
 
             case .switchToPreviousTab:
-                let selectedId = state.chatTapGroup.selectedTabId
-                guard let index = state.chatTapGroup.tabInfo
+                let selectedId = state.chatTabGroup.selectedTabId
+                guard let index = state.chatTabGroup.tabInfo
                     .firstIndex(where: { $0.id == selectedId })
                 else { return .none }
                 let previousIndex = index - 1
-                if previousIndex < 0 || previousIndex >= state.chatTapGroup.tabInfo.endIndex {
+                if previousIndex < 0 || previousIndex >= state.chatTabGroup.tabInfo.endIndex {
                     return .none
                 }
-                let targetId = state.chatTapGroup.tabInfo[previousIndex].id
-                state.chatTapGroup.selectedTabId = targetId
+                let targetId = state.chatTabGroup.tabInfo[previousIndex].id
+                state.chatTabGroup.selectedTabId = targetId
                 return .none
                 
             case .chatTab:
                 return .none
             }
-        }.forEach(\.chatTapGroup.tabInfo, action: /Action.chatTab) {
+        }.forEach(\.chatTabGroup.tabInfo, action: /Action.chatTab) {
             ChatTabItem()
         }
     }

--- a/Core/Sources/SuggestionWidget/FeatureReducers/WidgetFeature.swift
+++ b/Core/Sources/SuggestionWidget/FeatureReducers/WidgetFeature.swift
@@ -63,7 +63,7 @@ public struct WidgetFeature: ReducerProtocol {
                         }
                         return false
                     }(),
-                    isContentEmpty: chatPanelState.chatTapGroup.tabs.isEmpty
+                    isContentEmpty: chatPanelState.chatTapGroup.tabInfo.isEmpty
                         && panelState.sharedPanelState.content == nil,
                     isChatPanelDetached: chatPanelState.chatPanelInASeparateWindow,
                     isChatOpen: chatPanelState.isPanelDisplayed,
@@ -485,7 +485,7 @@ public struct WidgetFeature: ReducerProtocol {
 
             case .updateWindowOpacity:
                 let isChatPanelDetached = state.chatPanelState.chatPanelInASeparateWindow
-                let hasChat = !state.chatPanelState.chatTapGroup.tabs.isEmpty
+                let hasChat = !state.chatPanelState.chatTapGroup.tabInfo.isEmpty
 
                 return .run { _ in
                     Task { @MainActor in
@@ -539,15 +539,8 @@ public struct WidgetFeature: ReducerProtocol {
                     }
                 }
 
-            case let .circularWidget(action):
-                switch action {
-                case .openChatButtonClicked:
-                    suggestionWidgetControllerDependency.onOpenChatClicked()
-                    return .none
-
-                default:
-                    return .none
-                }
+            case .circularWidget:
+                return .none
 
             case .panel:
                 return .none

--- a/Core/Sources/SuggestionWidget/FeatureReducers/WidgetFeature.swift
+++ b/Core/Sources/SuggestionWidget/FeatureReducers/WidgetFeature.swift
@@ -63,7 +63,7 @@ public struct WidgetFeature: ReducerProtocol {
                         }
                         return false
                     }(),
-                    isContentEmpty: chatPanelState.chatTapGroup.tabInfo.isEmpty
+                    isContentEmpty: chatPanelState.chatTabGroup.tabInfo.isEmpty
                         && panelState.sharedPanelState.content == nil,
                     isChatPanelDetached: chatPanelState.chatPanelInASeparateWindow,
                     isChatOpen: chatPanelState.isPanelDisplayed,
@@ -485,7 +485,7 @@ public struct WidgetFeature: ReducerProtocol {
 
             case .updateWindowOpacity:
                 let isChatPanelDetached = state.chatPanelState.chatPanelInASeparateWindow
-                let hasChat = !state.chatPanelState.chatTapGroup.tabInfo.isEmpty
+                let hasChat = !state.chatPanelState.chatTabGroup.tabInfo.isEmpty
 
                 return .run { _ in
                     Task { @MainActor in

--- a/Core/Sources/SuggestionWidget/ModuleDependency.swift
+++ b/Core/Sources/SuggestionWidget/ModuleDependency.swift
@@ -1,9 +1,11 @@
 import ActiveApplicationMonitor
 import AppKit
+import ChatTab
 import ComposableArchitecture
 import Dependencies
 import Foundation
 import Preferences
+import SwiftUI
 import UserDefaultsObserver
 import XcodeInspector
 
@@ -133,4 +135,3 @@ extension DependencyValues {
         set { self[ActivateExtensionServiceKey.self] = newValue }
     }
 }
-

--- a/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
+++ b/Core/Sources/SuggestionWidget/SuggestionWidgetController.swift
@@ -2,6 +2,7 @@ import ActiveApplicationMonitor
 import AppKit
 import AsyncAlgorithms
 import AXNotificationStream
+import ChatTab
 import Combine
 import ComposableArchitecture
 import Environment
@@ -166,6 +167,7 @@ public final class SuggestionWidgetController: NSObject {
                     action: WidgetFeature.Action.chatPanel
                 )
             )
+            .environment(\.chatTabPool, chatTabPool)
         )
         it.setIsVisible(true)
         it.delegate = self
@@ -174,16 +176,19 @@ public final class SuggestionWidgetController: NSObject {
 
     let store: StoreOf<WidgetFeature>
     let viewStore: ViewStoreOf<WidgetFeature>
+    let chatTabPool: ChatTabPool
     private var cancellable = Set<AnyCancellable>()
 
     public let dependency: SuggestionWidgetControllerDependency
 
     public init(
         store: StoreOf<WidgetFeature>,
+        chatTabPool: ChatTabPool,
         dependency: SuggestionWidgetControllerDependency
     ) {
         self.dependency = dependency
         self.store = store
+        self.chatTabPool = chatTabPool
         viewStore = .init(store, observe: { $0 })
 
         super.init()

--- a/TestPlan.xctestplan
+++ b/TestPlan.xctestplan
@@ -119,6 +119,13 @@
         "identifier" : "ASTParserTests",
         "name" : "ASTParserTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Pro",
+        "identifier" : "ChatTabPersistentTests",
+        "name" : "ChatTabPersistentTests"
+      }
     }
   ],
   "version" : 1

--- a/Tool/Sources/ChatTab/ChatTab.swift
+++ b/Tool/Sources/ChatTab/ChatTab.swift
@@ -2,6 +2,10 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
+public extension Notification.Name {
+    static let chatTabDidChange = Notification.Name("chatTabDidChange")
+}
+
 public struct ChatTabInfo: Identifiable, Equatable {
     public var id: String
     public var title: String
@@ -126,6 +130,15 @@ public protocol ChatTabType {
     /// Available builders for this chat tab.
     /// It's used to generate a list of tab types for user to create.
     static func chatBuilders(externalDependency: ExternalDependency) -> [ChatTabBuilder]
+    /// Restorable state
+    func restorableState() async -> Data
+    /// Restore state
+    static func restore(from data: Data, externalDependency: ExternalDependency) async throws
+        -> any ChatTab
+}
+
+public extension ChatTabType {
+    var name: String { Self.name }
 }
 
 public extension ChatTabType where ExternalDependency == Void {
@@ -164,6 +177,17 @@ public class EmptyChatTab: ChatTab {
 
     public init(id: String = UUID().uuidString) {
         super.init(id: id, title: "Empty")
+    }
+
+    public func restorableState() async -> Data {
+        return Data()
+    }
+
+    public static func restore(
+        from data: Data,
+        externalDependency: Void
+    ) async throws -> any ChatTab {
+        return Builder(title: "Empty").build()
     }
 }
 

--- a/Tool/Sources/ChatTab/ChatTab.swift
+++ b/Tool/Sources/ChatTab/ChatTab.swift
@@ -2,10 +2,7 @@ import ComposableArchitecture
 import Foundation
 import SwiftUI
 
-public extension Notification.Name {
-    static let chatTabDidChange = Notification.Name("chatTabDidChange")
-}
-
+/// The information of a tab.
 public struct ChatTabInfo: Identifiable, Equatable {
     public var id: String
     public var title: String
@@ -16,63 +13,68 @@ public struct ChatTabInfo: Identifiable, Equatable {
     }
 }
 
-public struct ChatTabInfoPreferenceKey: PreferenceKey {
-    public static var defaultValue: [ChatTabInfo] = []
-    public static func reduce(value: inout [ChatTabInfo], nextValue: () -> [ChatTabInfo]) {
-        value.append(contentsOf: nextValue())
-    }
-}
-
 /// Every chat tab should conform to this type.
 public typealias ChatTab = BaseChatTab & ChatTabType
 
-/// The base class for all chat tabs.
-open class BaseChatTab: Equatable {
-    /// To support dynamic update of title in view.
-    final class InfoObservable: ObservableObject {
-        @Published var id: String
-        @Published var title: String
-        init(id: String, title: String) {
-            self.title = title
-            self.id = id
-        }
-    }
+/// Defines a bunch of things a chat tab should implement.
+public protocol ChatTabType {
+    /// The type of the external dependency required by this chat tab.
+    associatedtype ExternalDependency
+    /// Build the view for this chat tab.
+    @ViewBuilder
+    func buildView() -> any View
+    /// Build the menu for this chat tab.
+    @ViewBuilder
+    func buildMenu() -> any View
+    /// The name of this chat tab type.
+    static var name: String { get }
+    /// Available builders for this chat tab.
+    /// It's used to generate a list of tab types for user to create.
+    static func chatBuilders(externalDependency: ExternalDependency) -> [ChatTabBuilder]
+    /// Restorable state
+    func restorableState() async -> Data
+    /// Restore state
+    static func restore(
+        from data: Data,
+        store: StoreOf<ChatTabItem>,
+        externalDependency: ExternalDependency
+    ) async throws -> any ChatTab
+    /// Whenever the body or menu is accessed, this method will be called.
+    /// It will be called only once so long as you don't call it yourself.
+    /// It will be called from MainActor.
+    func start()
+}
 
+/// The base class for all chat tabs.
+open class BaseChatTab {
     /// A wrapper to support dynamic update of title in view.
     struct ContentView: View {
-        @ObservedObject var info: InfoObservable
         var buildView: () -> any View
         var body: some View {
             AnyView(buildView())
-                .preference(
-                    key: ChatTabInfoPreferenceKey.self,
-                    value: [ChatTabInfo(
-                        id: info.id,
-                        title: info.title
-                    )]
-                )
         }
     }
 
-    public let id: String
-    public var title: String {
-        didSet { info.title = title }
-    }
+    public var id: String { chatTabViewStore.id }
+    public var title: String { chatTabViewStore.title }
+    public let chatTabStore: StoreOf<ChatTabItem>
+    public let chatTabViewStore: ViewStoreOf<ChatTabItem>
+    private var didStart = false
 
-    let info: InfoObservable
-
-    public init(id: String, title: String) {
-        self.id = id
-        self.title = title
-        info = InfoObservable(id: id, title: title)
+    public init(store: StoreOf<ChatTabItem>) {
+        chatTabStore = store
+        chatTabViewStore = ViewStore(store)
     }
 
     /// The view for this chat tab.
     @ViewBuilder
     public var body: some View {
-        let id = "ChatTabBody\(info.id)"
+        let id = "ChatTabBody\(id)"
         if let tab = self as? (any ChatTabType) {
-            ContentView(info: info, buildView: tab.buildView).id(id)
+            ContentView(buildView: tab.buildView).id(id)
+                .onAppear {
+                    Task { @MainActor in self.startIfNotStarted() }
+                }
         } else {
             EmptyView().id(id)
         }
@@ -81,16 +83,25 @@ open class BaseChatTab: Equatable {
     /// The menu for this chat tab.
     @ViewBuilder
     public var menu: some View {
-        let id = "ChatTabMenu\(info.id)"
+        let id = "ChatTabMenu\(id)"
         if let tab = self as? (any ChatTabType) {
-            ContentView(info: info, buildView: tab.buildMenu).id(id)
+            ContentView(buildView: tab.buildMenu).id(id)
+                .onAppear {
+                    Task { @MainActor in self.startIfNotStarted() }
+                }
         } else {
             EmptyView().id(id)
         }
     }
 
-    public static func == (lhs: BaseChatTab, rhs: BaseChatTab) -> Bool {
-        lhs.id == rhs.id
+    @MainActor
+    func startIfNotStarted() {
+        guard !didStart else { return }
+        didStart = true
+
+        if let tab = self as? (any ChatTabType) {
+            tab.start()
+        }
     }
 }
 
@@ -101,14 +112,15 @@ public protocol ChatTabBuilder {
     /// whether the chat tab is buildable.
     var buildable: Bool { get }
     /// Build the chat tab.
-    func build() -> any ChatTab
+    func build(store: StoreOf<ChatTabItem>) -> any ChatTab
 }
 
+/// A chat tab builder that doesn't build.
 public struct DisabledChatTabBuilder: ChatTabBuilder {
     public var title: String
     public var buildable: Bool { false }
-    public func build() -> any ChatTab {
-        EmptyChatTab(id: UUID().uuidString)
+    public func build(store: StoreOf<ChatTabItem>) -> any ChatTab {
+        EmptyChatTab(store: store)
     }
 
     public init(title: String) {
@@ -116,28 +128,8 @@ public struct DisabledChatTabBuilder: ChatTabBuilder {
     }
 }
 
-public protocol ChatTabType {
-    /// The type of the external dependency required by this chat tab.
-    associatedtype ExternalDependency
-    /// Build the view for this chat tab.
-    @ViewBuilder
-    func buildView() -> any View
-    /// Build the menu for this chat tab.
-    @ViewBuilder
-    func buildMenu() -> any View
-    /// The name of this chat tab.
-    static var name: String { get }
-    /// Available builders for this chat tab.
-    /// It's used to generate a list of tab types for user to create.
-    static func chatBuilders(externalDependency: ExternalDependency) -> [ChatTabBuilder]
-    /// Restorable state
-    func restorableState() async -> Data
-    /// Restore state
-    static func restore(from data: Data, externalDependency: ExternalDependency) async throws
-        -> any ChatTab
-}
-
 public extension ChatTabType {
+    /// The name of this chat tab type.
     var name: String { Self.name }
 }
 
@@ -149,14 +141,15 @@ public extension ChatTabType where ExternalDependency == Void {
     }
 }
 
+/// A chat tab that does nothing.
 public class EmptyChatTab: ChatTab {
     public static var name: String { "Empty" }
 
     struct Builder: ChatTabBuilder {
         let title: String
         var buildable: Bool { true }
-        func build() -> any ChatTab {
-            EmptyChatTab()
+        func build(store: StoreOf<ChatTabItem>) -> any ChatTab {
+            EmptyChatTab(store: store)
         }
     }
 
@@ -175,19 +168,27 @@ public class EmptyChatTab: ChatTab {
         EmptyView()
     }
 
-    public init(id: String = UUID().uuidString) {
-        super.init(id: id, title: "Empty")
-    }
-
     public func restorableState() async -> Data {
         return Data()
     }
 
     public static func restore(
         from data: Data,
+        store: StoreOf<ChatTabItem>,
         externalDependency: Void
     ) async throws -> any ChatTab {
-        return Builder(title: "Empty").build()
+        return Builder(title: "Empty").build(store: store)
+    }
+
+    public convenience init(id: String) {
+        self.init(store: .init(
+            initialState: .init(id: id, title: "Empty-\(id)"),
+            reducer: ChatTabItem()
+        ))
+    }
+
+    public func start() {
+        chatTabViewStore.send(.updateTitle("Empty-\(id)"))
     }
 }
 

--- a/Tool/Sources/ChatTab/ChatTabItem.swift
+++ b/Tool/Sources/ChatTab/ChatTabItem.swift
@@ -1,0 +1,38 @@
+import ComposableArchitecture
+import Foundation
+
+public struct AnyChatTabBuilder: Equatable {
+    public static func == (lhs: AnyChatTabBuilder, rhs: AnyChatTabBuilder) -> Bool {
+        true
+    }
+
+    public let chatTabBuilder: any ChatTabBuilder
+
+    public init(_ chatTabBuilder: any ChatTabBuilder) {
+        self.chatTabBuilder = chatTabBuilder
+    }
+}
+
+public struct ChatTabItem: ReducerProtocol {
+    public typealias State = ChatTabInfo
+
+    public enum Action: Equatable {
+        case updateTitle(String)
+        case openNewTab(AnyChatTabBuilder)
+    }
+
+    public init() {}
+
+    public var body: some ReducerProtocol<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case let .updateTitle(title):
+                state.title = title
+                return .none
+            case .openNewTab:
+                return .none
+            }
+        }
+    }
+}
+

--- a/Tool/Sources/ChatTab/ChatTabItem.swift
+++ b/Tool/Sources/ChatTab/ChatTabItem.swift
@@ -19,6 +19,7 @@ public struct ChatTabItem: ReducerProtocol {
     public enum Action: Equatable {
         case updateTitle(String)
         case openNewTab(AnyChatTabBuilder)
+        case tabContentUpdated
     }
 
     public init() {}
@@ -30,6 +31,8 @@ public struct ChatTabItem: ReducerProtocol {
                 state.title = title
                 return .none
             case .openNewTab:
+                return .none
+            case .tabContentUpdated:
                 return .none
             }
         }

--- a/Tool/Sources/ChatTab/ChatTabPool.swift
+++ b/Tool/Sources/ChatTab/ChatTabPool.swift
@@ -1,0 +1,54 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import SwiftUI
+
+/// A pool that stores all the available tabs.
+public final class ChatTabPool {
+    public var createStore: (String) -> StoreOf<ChatTabItem> = { id in
+        .init(
+            initialState: .init(id: id, title: ""),
+            reducer: ChatTabItem()
+        )
+    }
+
+    private var pool: [String: any ChatTab]
+
+    public init(_ pool: [String: any ChatTab] = [:]) {
+        self.pool = pool
+    }
+
+    public func getTab(of id: String) -> (any ChatTab)? {
+        pool[id]
+    }
+
+    public func setTab(_ tab: any ChatTab) {
+        pool[tab.id] = tab
+    }
+
+    public func removeTab(of id: String) {
+        pool.removeValue(forKey: id)
+    }
+}
+
+public struct ChatTabPoolDependencyKey: DependencyKey {
+    public static let liveValue = ChatTabPool()
+}
+
+public extension DependencyValues {
+    var chatTabPool: ChatTabPool {
+        get { self[ChatTabPoolDependencyKey.self] }
+        set { self[ChatTabPoolDependencyKey.self] = newValue }
+    }
+}
+
+public struct ChatTabPoolEnvironmentKey: EnvironmentKey {
+    public static let defaultValue = ChatTabPool()
+}
+
+public extension EnvironmentValues {
+    var chatTabPool: ChatTabPool {
+        get { self[ChatTabPoolEnvironmentKey.self] }
+        set { self[ChatTabPoolEnvironmentKey.self] = newValue }
+    }
+}

--- a/Tool/Sources/OpenAIService/Configuration/UserPreferenceChatGPTConfiguration.swift
+++ b/Tool/Sources/OpenAIService/Configuration/UserPreferenceChatGPTConfiguration.swift
@@ -44,7 +44,7 @@ public struct UserPreferenceChatGPTConfiguration: ChatGPTConfiguration {
 }
 
 public class OverridingChatGPTConfiguration: ChatGPTConfiguration {
-    public struct Overriding {
+    public struct Overriding: Codable {
         public var featureProvider: ChatFeatureProvider?
         public var temperature: Double?
         public var model: String?

--- a/Tool/Sources/Preferences/Types/ChatFeatureProvider.swift
+++ b/Tool/Sources/Preferences/Types/ChatFeatureProvider.swift
@@ -1,4 +1,4 @@
-public enum ChatFeatureProvider: String, CaseIterable {
+public enum ChatFeatureProvider: String, CaseIterable, Codable {
     case openAI
     case azureOpenAI
 }


### PR DESCRIPTION
Add ChatTabPool. The store won't hold the actual chat tab classes any more.
Add ChatTabItem to allow chat tabs to send actions to the store.
Add ChatTabPersistent to provide persistence for tabs.