### PR TITLE
Adjust position of context system prompt

### DIFF
--- a/Core/Sources/ChatService/DynamicContextController.swift
+++ b/Core/Sources/ChatService/DynamicContextController.swift
@@ -92,7 +92,7 @@ final class DynamicContextController {
             return contexts
         }
 
-        let extraSystemPrompt = contexts
+        let contextSystemPrompt = contexts
             .map(\.systemPrompt)
             .filter { !$0.isEmpty }
             .joined(separator: "\n\n")
@@ -104,9 +104,10 @@ final class DynamicContextController {
 
         let contextualSystemPrompt = """
         \(language.isEmpty ? "" : "You must always reply in \(language)")
-        \(systemPrompt)\(extraSystemPrompt.isEmpty ? "" : "\n\(extraSystemPrompt)")
+        \(systemPrompt)
         """
         await memory.mutateSystemPrompt(contextualSystemPrompt)
+        await memory.mutateContextSystemPrompt(contextSystemPrompt)
         await memory.mutateRetrievedContent(contextPrompts.map(\.content))
         functionProvider.append(functions: contexts.flatMap(\.functions))
     }


### PR DESCRIPTION
#385 

Sometimes, LLM can't find the code in the top most system prompt, so I am moving the system prompts generated by context collectors to right above the latest message.

This is what GitHub Copilot Chat is doing, so I think it should make it work better.