### PR TITLE
Update Codeium enterprise register user path

### DIFF
--- a/Tool/Sources/CodeiumService/CodeiumAuthService.swift
+++ b/Tool/Sources/CodeiumService/CodeiumAuthService.swift
@@ -38,7 +38,7 @@ public final class CodeiumAuthService {
         let apiUrl = UserDefaults.shared.value(for: \.codeiumApiUrl)
         if UserDefaults.shared.value(for: \.codeiumEnterpriseMode), apiUrl != "" {
             registerUserUrl =
-                URL(string: apiUrl + "/exa.api_server_pb.ApiServerService/RegisterUser")
+                URL(string: apiUrl + "/exa.seat_management_pb.SeatManagementService/RegisterUser")
         }
 
         var request = URLRequest(url: registerUserUrl!)


### PR DESCRIPTION
Appears Codeium register user path is out of date. This PR updates path to match what is in other plugins like this: https://github.com/Exafunction/codeium.vim/blob/fd440cd718742daab162241c5bd5857cd92f5f72/autoload/codeium/command.vim#L88

Thank you.