### PR TITLE
Add a default role to stream response

### DIFF
--- a/Tool/Sources/OpenAIService/ChatGPTService.swift
+++ b/Tool/Sources/OpenAIService/ChatGPTService.swift
@@ -330,6 +330,7 @@ extension ChatGPTService {
                 do {
                     await memory.streamMessage(
                         id: proposedId,
+                        role: .assistant,
                         references: prompt.references
                     )
                     let chunks = try await api()


### PR DESCRIPTION
Just in case any service doesn't specify a role in the response #449 