### PR TITLE
Remove snapshot check fetching suggestion manually

### DIFF
--- a/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
+++ b/Core/Sources/Service/SuggestionCommandHandler/WindowBaseCommandHandler.swift
@@ -46,14 +46,6 @@ struct WindowBaseCommandHandler: SuggestionCommandHandler {
 
         try Task.checkCancellation()
 
-        let snapshot = FilespaceSuggestionSnapshot(
-            linesHash: editor.lines.hashValue,
-            cursorPosition: editor.cursorPosition
-        )
-
-        // There is no need to regenerate suggestions for the same editor content.
-        guard filespace.suggestionSourceSnapshot != snapshot else { return }
-
         try await workspace.generateSuggestions(
             forFileAt: fileURL,
             editor: editor


### PR DESCRIPTION
Back in the day we were using commands to generate real-time suggestions. But we don't need it anymore. #454 