### PR TITLE
Bump codeium language server 1.8.8

### DIFF
--- a/Tool/Sources/CodeiumService/CodeiumInstallationManager.swift
+++ b/Tool/Sources/CodeiumService/CodeiumInstallationManager.swift
@@ -3,7 +3,7 @@ import Terminal
 
 public struct CodeiumInstallationManager {
     private static var isInstalling = false
-    static let latestSupportedVersion = "1.8.5"
+    static let latestSupportedVersion = "1.8.8"
 
     public init() {}
 


### PR DESCRIPTION
1.8.9 doesn't have a macOS version, so 1.8.8 is the latest