### PR TITLE
fix: update version of swift-markdown-ui and TCA to fix compile error  of swift 6

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -39,13 +39,13 @@ let package = Package(
         .package(path: "../Tool"),
         .package(path: "../ChatPlugins"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
-        .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.1.0"),
+        .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.1"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-parsing", from: "0.12.1"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
         .package(
             url: "https://github.com/pointfreeco/swift-composable-architecture",
-            exact: "1.15.0"
+            exact: "1.16.1"
         ),
         // quick hack to support custom UserDefaults
         // https://github.com/sindresorhus/KeyboardShortcuts

--- a/Tool/Package.swift
+++ b/Tool/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
         .package(url: "https://github.com/intitni/Highlightr", branch: "master"),
         .package(
             url: "https://github.com/pointfreeco/swift-composable-architecture",
-            exact: "1.15.0"
+            exact: "1.16.1"
         ),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0"),
         .package(url: "https://github.com/GottaGetSwifty/CodableWrappers", from: "2.0.7"),


### PR DESCRIPTION
Compile error in the latest version's Xcode 16.