### PR TITLE
Fix that activate app brings all windows to front

### DIFF
--- a/Tool/Sources/AppActivator/AppActivator.swift
+++ b/Tool/Sources/AppActivator/AppActivator.swift
@@ -16,9 +16,11 @@ public extension NSWorkspace {
             if activated { return }
 
             // Fallback solution
-            
-            let axApplication = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
-            axApplication.isFrontmost = true
+
+            let axApplication = AXUIElementCreateApplication(
+                ProcessInfo.processInfo.processIdentifier
+            )
+            activateAppElement(axApplication)
 //
 //            let appleScript = """
 //            tell application "System Events"
@@ -35,8 +37,7 @@ public extension NSWorkspace {
             guard let app = await XcodeInspector.shared.safe.previousActiveApplication
             else { return }
             try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            app.appElement.isFrontmost = true
-//            _ = app.activate()
+            activateApp(app)
         }
     }
 
@@ -44,9 +45,19 @@ public extension NSWorkspace {
         Task { @MainActor in
             guard let app = await XcodeInspector.shared.safe.latestActiveXcode else { return }
             try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            app.appElement.isFrontmost = true
-//            _ = app.activate()
+            activateApp(app)
         }
+    }
+
+    static func activateApp(_ app: AppInstanceInspector) {
+        // we prefer `.activate()` because it only brings the active window to the front
+        if !app.activate() {
+            activateAppElement(app.appElement)
+        }
+    }
+
+    static func activateAppElement(_ appElement: AXUIElement) {
+        appElement.isFrontmost = true
     }
 }
 

--- a/Tool/Sources/XcodeInspector/XcodeInspector+TriggerCommand.swift
+++ b/Tool/Sources/XcodeInspector/XcodeInspector+TriggerCommand.swift
@@ -30,13 +30,12 @@ public extension AppInstanceInspector {
         guard path.count >= 2 else { throw cantRunCommand("Path too short.") }
 
         if activateApp {
-            appElement.isFrontmost = true
-//            if !runningApplication.activate() {
-//                Logger.service.error("""
-//                Trigger menu item \(sourcePath): \
-//                Xcode not activated.
-//                """)
-//            }
+            if !runningApplication.isActive {
+                // we prefer `.activate()` because it only brings the active window to the front
+                if !activate() {
+                    appElement.isFrontmost = true
+                }
+            }
         } else {
             if !runningApplication.isActive {
                 Logger.service.error("""


### PR DESCRIPTION
Looks like setting frontmost to true brings all window to the front. The only solution is to bring back `.activate()` and fallback to `isFrontmost` when it fails for some users.

Another tweak is that we will check if the app is already frontmost before activating the app.

#616 