### PR TITLE
Authenticate when sending requests to Ollama

### DIFF
--- a/Core/Sources/HostApp/AccountSettings/ChatModelManagement/ChatModelEditView.swift
+++ b/Core/Sources/HostApp/AccountSettings/ChatModelManagement/ChatModelEditView.swift
@@ -380,6 +380,8 @@ struct ChatModelEditView: View {
                 BaseURLTextField(store: store, prompt: Text("http://127.0.0.1:11434")) {
                     Text("/api/chat")
                 }
+				
+				ApiKeyNamePicker(store: store)
 
                 TextField("Model Name", text: $store.modelName)
 

--- a/Tool/Sources/OpenAIService/APIs/OlamaChatCompletionsService.swift
+++ b/Tool/Sources/OpenAIService/APIs/OlamaChatCompletionsService.swift
@@ -59,6 +59,7 @@ extension OllamaChatCompletionsService: ChatCompletionsAPI {
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(requestBody)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         let (result, response) = try await URLSession.shared.data(for: request)
 
         guard let response = response as? HTTPURLResponse else {
@@ -135,6 +136,7 @@ extension OllamaChatCompletionsService: ChatCompletionsStreamAPI {
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(requestBody)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         let (result, response) = try await URLSession.shared.bytes(for: request)
 
         guard let response = response as? HTTPURLResponse else {

--- a/Tool/Sources/OpenAIService/APIs/OlamaChatCompletionsService.swift
+++ b/Tool/Sources/OpenAIService/APIs/OlamaChatCompletionsService.swift
@@ -59,7 +59,11 @@ extension OllamaChatCompletionsService: ChatCompletionsAPI {
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(requestBody)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+		
+		if !apiKey.isEmpty {
+			request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+		}
+		
         let (result, response) = try await URLSession.shared.data(for: request)
 
         guard let response = response as? HTTPURLResponse else {
@@ -136,7 +140,11 @@ extension OllamaChatCompletionsService: ChatCompletionsStreamAPI {
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(requestBody)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-		request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+		
+		if !apiKey.isEmpty {
+			request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+		}
+		
         let (result, response) = try await URLSession.shared.bytes(for: request)
 
         guard let response = response as? HTTPURLResponse else {


### PR DESCRIPTION
### Motivation
Using Ollama through OpenWebUI requires clients to send an API token with their requests in order to interact with a model. OpenWebUI's documentation on the topic can be found [here](https://docs.openwebui.com/getting-started/api-endpoints#-retrieve-all-models).

### Implementation
- I've added the `ApiKeyNamePicker` to the `OllamaForm`.
- I've implemented adding the `Bearer` header to the URL requests in `OllamaChatCompletionsService`.