### PR TITLE
Temporary fix for WindowServer high GPU usage when idle

### DIFF
--- a/Core/Sources/SuggestionWidget/ChatPanelWindow.swift
+++ b/Core/Sources/SuggestionWidget/ChatPanelWindow.swift
@@ -51,10 +51,7 @@ final class ChatPanelWindow: WidgetWindow {
         }())
         titlebarAppearsTransparent = true
         isReleasedWhenClosed = false
-        isOpaque = false
-        backgroundColor = .clear
         level = widgetLevel(1)
-
         hasShadow = true
         contentView = NSHostingView(
             rootView: ChatWindowView(

--- a/Core/Sources/SuggestionWidget/WidgetWindowsController.swift
+++ b/Core/Sources/SuggestionWidget/WidgetWindowsController.swift
@@ -479,7 +479,6 @@ extension WidgetWindowsController {
             )
 
             if let suggestionPanelLocation = widgetLocation.suggestionPanelLocation {
-                print(suggestionPanelLocation)
                 windows.suggestionPanelWindow.setFrame(
                     suggestionPanelLocation.frame,
                     display: false,
@@ -705,7 +704,7 @@ public final class WidgetWindows {
             defer: false
         )
         it.isReleasedWhenClosed = false
-        it.isOpaque = false
+        it.isOpaque = true
         it.backgroundColor = .clear
         it.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
         it.hasShadow = false
@@ -723,10 +722,10 @@ public final class WidgetWindows {
             defer: false
         )
         it.isReleasedWhenClosed = false
-        it.isOpaque = false
+        it.isOpaque = true
         it.backgroundColor = .clear
         it.level = widgetLevel(0)
-        it.hasShadow = true
+        it.hasShadow = false
         it.contentView = NSHostingView(
             rootView: WidgetView(
                 store: store.scope(
@@ -749,11 +748,11 @@ public final class WidgetWindows {
             defer: false
         )
         it.isReleasedWhenClosed = false
-        it.isOpaque = false
+        it.isOpaque = true
         it.backgroundColor = .clear
         it.level = widgetLevel(2)
         it.hoveringLevel = widgetLevel(2)
-        it.hasShadow = true
+        it.hasShadow = false
         it.contentView = NSHostingView(
             rootView: SharedPanelView(
                 store: store.scope(
@@ -783,10 +782,12 @@ public final class WidgetWindows {
             defer: false
         )
         it.isReleasedWhenClosed = false
-        it.isOpaque = false
+        it.isOpaque = true
         it.backgroundColor = .clear
         it.level = widgetLevel(2)
-        it.hasShadow = true
+        it.hasShadow = false
+        it.menu = nil
+        it.animationBehavior = .utilityWindow
         it.contentView = NSHostingView(
             rootView: SuggestionPanelView(
                 store: store.scope(
@@ -881,6 +882,8 @@ class WidgetWindow: CanBecomeKeyWindow {
     }
 
     var hoveringLevel: NSWindow.Level = widgetLevel(0)
+    
+    override var isFloatingPanel: Bool { true }
 
     var defaultCollectionBehavior: NSWindow.CollectionBehavior {
         [.fullScreenAuxiliary, .transient]

--- a/OverlayWindow/Sources/OverlayWindow/OverlayPanel.swift
+++ b/OverlayWindow/Sources/OverlayWindow/OverlayPanel.swift
@@ -1,7 +1,7 @@
 import AppKit
+import Logger
 import Perception
 import SwiftUI
-import Logger
 
 struct OverlayFrameEnvironmentKey: EnvironmentKey {
     static let defaultValue: CGRect = .zero
@@ -24,7 +24,7 @@ public extension EnvironmentValues {
 }
 
 @MainActor
-final class OverlayPanel: NSPanel {
+public final class OverlayPanel: NSPanel {
     @MainActor
     @Perceptible
     final class PanelState {
@@ -35,7 +35,7 @@ final class OverlayPanel: NSPanel {
     let panelState: PanelState = .init()
     private var _canBecomeKey = true
 
-    init<Content: View>(
+    public init<Content: View>(
         contentRect: NSRect,
         @ViewBuilder content: @escaping () -> Content
     ) {
@@ -71,21 +71,21 @@ final class OverlayPanel: NSPanel {
         )
     }
 
-    override var canBecomeKey: Bool {
+    override public var canBecomeKey: Bool {
         return _canBecomeKey
     }
 
-    override var canBecomeMain: Bool {
+    override public var canBecomeMain: Bool {
         return false
     }
-    
-    override func setIsVisible(_ visible: Bool) {
+
+    override public func setIsVisible(_ visible: Bool) {
         _canBecomeKey = false
         defer { _canBecomeKey = true }
         super.setIsVisible(visible)
     }
 
-    func moveToActiveSpace() {
+    public func moveToActiveSpace() {
         collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
         Task { @MainActor in
             try await Task.sleep(nanoseconds: 50_000_000)

--- a/OverlayWindow/Sources/OverlayWindow/OverlayPanel.swift
+++ b/OverlayWindow/Sources/OverlayWindow/OverlayPanel.swift
@@ -52,9 +52,9 @@ final class OverlayPanel: NSPanel {
 
         isReleasedWhenClosed = false
         menu = nil
-        isOpaque = false
+        isOpaque = true
         backgroundColor = .clear
-        hasShadow = true
+        hasShadow = false
         alphaValue = 1.0
         collectionBehavior = [.fullScreenAuxiliary]
         isFloatingPanel = true


### PR DESCRIPTION
It looks like the shadow of the floating transparent windows are make WindowServer run under pressure. So I temporarily disabled the shadows. It doesn't look as good so we need a better solution.

Also Xcode itself is pushing WindowServer hard when the builtin chat panel is displayed, too.